### PR TITLE
Add view implementation and testing plan

### DIFF
--- a/Docs/ViewImplementationPlan/README.md
+++ b/Docs/ViewImplementationPlan/README.md
@@ -1,0 +1,60 @@
+## 10. View Implementation and Testing Plan
+
+This document outlines how to implement the Teatro view system and how each view should be unit tested. The plan follows the structures defined in the existing documentation and assumes that the Swift package layout remains consistent with the **Summary** guide.
+
+### 10.1 Core Protocols
+Implement the protocols under `Sources/ViewCore`:
+
+- **Renderable** – exposes `render() -> String`.
+- **Layouting** – extends `Renderable` with alignment and padding properties.
+- **Alignment** – enum describing `.leading`, `.center`, `.trailing`.
+- **TextStyle** – enum with `.bold`, `.italic`, `.underline`, `.plain` plus `apply(to:)`.
+- **ViewBuilder** – result builder returning `[Renderable]`.
+
+Tests should verify protocol conformance for all view types and confirm that `TextStyle.apply` returns the expected string for each case.
+
+### 10.2 Basic View Types
+Implement the primary views from `Docs/ViewTypes` in `Sources/ViewCore`:
+
+1. **Text** – renders styled text via `TextStyle.apply`.
+2. **VStack** – vertically stacks child views with padding and alignment.
+3. **HStack** – horizontally stacks child views with padding.
+4. **Stage** – top-level container that prepends a title.
+5. **TeatroIcon** – renders a symbolic icon with the `◉` prefix.
+
+Testing strategy:
+- Unit tests should instantiate each view with sample data and verify the exact string returned by `render()`.
+- For `VStack` and `HStack`, include tests with multiple child views and custom padding to ensure indentation and spacing rules.
+
+### 10.3 Specialized Views
+Additional renderable components appear in other documentation sections:
+
+- **LilyScore** (`Docs/LilyPondMusicRendering`) – simple wrapper that renders its content string and provides a `renderToPDF` helper. Unit tests should verify the plain `render()` output. PDF generation can be tested with a temporary directory and checking that files are created.
+- **FountainElement** and **FountainSceneView** (`Docs/FountainScreenplayEngine`) – parse Fountain text into elements and render each one. Tests should parse a short script and validate the resulting array of `FountainElement` cases as well as the final rendered string.
+
+### 10.4 Renderers and CLI
+Although not strictly views, renderers are important for integration testing:
+
+- Implement `HTMLRenderer`, `SVGRenderer`, `ImageRenderer`, and `CodexPreviewer` under `Sources/Renderers` exactly as shown in the docs.
+- Implement `RenderCLI` in `Sources/CLI` to wire up the renderers. Use `swift run` in tests to ensure the binary can be invoked with different targets.
+
+### 10.5 Animation System
+Implement `Animator` under `Sources/Renderers` or a dedicated `Sources/Animation` folder. Tests should create a series of views, call `Animator.renderFrames`, and confirm that the expected `.png` files appear in `Animations/`.
+
+### 10.6 Test Organization
+Create test files in `Tests/` following SwiftPM conventions:
+
+- `ViewCoreTests.swift` – covers protocols and basic view types.
+- `MusicViewTests.swift` – tests `LilyScore` behaviour.
+- `FountainViewTests.swift` – tests screenplay parsing and rendering.
+- `RendererTests.swift` – verifies HTML/SVG output strings and image file creation (Cairo can be mocked if unavailable).
+- `CLITests.swift` – uses `Process` to run the CLI with different arguments and checks the output or generated files.
+
+Each test should clean up temporary files after execution to keep the repository tidy.
+
+### 10.7 Continuous Testing
+Update `Package.swift` to add library and executable targets for the new sources. Ensure that `swift test` passes locally. Consider adding a simple GitHub Actions workflow later to run `swift build` and `swift test` on push.
+
+---
+
+Following this implementation and testing plan will produce a fully functional Teatro View Engine with deterministic rendering logic and comprehensive unit coverage for every view.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository contains the specification for Teatro, a modular Swift 6 view en
 - [LilyPond Music Rendering](Docs/LilyPondMusicRendering/README.md)
 - [MIDI 2.0 DSL](Docs/MIDI20DSL/README.md)
 - [Fountain Screenplay Engine](Docs/FountainScreenplayEngine/README.md)
+- [View Implementation and Testing Plan](Docs/ViewImplementationPlan/README.md)
 - [Summary](Docs/Summary/README.md)
 - [Addendum: Apple Platform Compatibility](Docs/Addendum/README.md)
 


### PR DESCRIPTION
## Summary
- create **ViewImplementationPlan** docs folder
- outline implementation steps for all view types and test strategies
- link the new plan from the README

## Testing
- `swift build`
- `swift test` *(fails: no tests yet)*

------
https://chatgpt.com/codex/tasks/task_e_686a3e6dc3908325ae282e209c765145