### PR TITLE
doc: add implementation status and action plan

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -302,7 +302,7 @@ paths:
 - Use the Swift 6.1 toolchain.
 - Run `swift build` and `swift test` before committing code.
 - Follow the directory conventions described in `Docs/Summary/README.md`.
-- Keep `Docs/ImplementationPlan` updated when priorities shift.
+- Maintain `Docs/ImplementationPlan.md` as the status quo and action planning record, updating it whenever priorities or implementation state change.
 
 ## Project Highlights
 - Modular `Renderable` protocol with multiple rendering backends.

--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -1,0 +1,24 @@
+# Implementation Plan
+
+## Status Quo
+
+- CLI handles `.fountain`, `.ly`, and `.csd` inputs; `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` inputs are unimplemented.
+- UMP rendering target is listed but missing from dispatch.
+- Environment variable precedence for width/height only applies when flags are set; no fallback to existing variables.
+- Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
+- Tests only cover help/version output and unknown flags. `swift test` fails to compile without Csound headers.
+
+## Action Plan
+
+1. Implement parsers and renderers for `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` files.
+2. Add `ump` output target in the render dispatcher and ensure all formats are documented.
+3. Apply environment variable fallback when width/height flags are absent and add tests for precedence.
+4. Replace polling watch mode with `DispatchSource.makeFileSystemObjectSource`.
+5. Expand test suite to cover argument parsing, watch/dispatch logic, output correctness, and environment variable precedence.
+6. Resolve Csound dependency for tests through conditional compilation or bundled headers.
+7. Update CLI help text and docs to reflect new inputs, outputs, and features.
+8. Maintain this file with up-to-date status and tasks as work progresses.
+
+---
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document CLI status quo and planned tasks
- note maintenance of implementation plan in contributor guidelines

## Testing
- `swift build` *(fails: could not build C module 'CCsound')*
- `swift test` *(fails: header '/usr/include/csound/csound.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68900bc84f908325940fc20ed2a4e811