### PR TITLE
Add MIDI file header parser scaffolding

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,10 +7,11 @@
 - Environment variable precedence for width/height only applies when flags are set; no fallback to existing variables.
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
 - Tests only cover help/version output and unknown flags. `swift test` fails to compile without Csound headers.
+- Initial `MidiFileParser` parses SMF header; full track parsing remains pending.
 
 ## Action Plan
 
-1. Implement parsers and renderers for `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` files.
+1. Implement parsers and renderers for `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` files (SMF header parser implemented).
 2. Add `ump` output target in the render dispatcher and ensure all formats are documented.
 3. Apply environment variable fallback when width/height flags are absent and add tests for precedence.
 4. Replace polling watch mode with `DispatchSource.makeFileSystemObjectSource`.

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             name: "Teatro",
             dependencies: ["CCsound", "CFluidSynth"],
             path: "Sources",
-            exclude: ["CLI", "TeatroSamplerDemo"]
+            exclude: ["CLI", "TeatroSamplerDemo", "Parsers/agent.md"]
         ),
         .executableTarget(
             name: "RenderCLI",

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Represents the header of a Standard MIDI File.
+struct MidiFileHeader {
+    let format: UInt16
+    let trackCount: UInt16
+    let division: UInt16
+}
+
+/// Errors that can occur while parsing a Standard MIDI File.
+enum MidiFileParserError: Error {
+    case invalidHeader
+}
+
+/// Parser for Standard MIDI Files (SMF).
+struct MidiFileParser {
+    /// Parses the header chunk (MThd) of a MIDI file.
+    /// - Parameter data: The raw data of the MIDI file beginning at the header.
+    /// - Returns: A `MidiFileHeader` describing the file.
+    static func parseHeader(data: Data) throws -> MidiFileHeader {
+        guard data.count >= 14 else { throw MidiFileParserError.invalidHeader }
+        let magic = data.prefix(4)
+        guard magic == Data([0x4D, 0x54, 0x68, 0x64]) else { throw MidiFileParserError.invalidHeader }
+        let length = UInt32(bigEndian: data[4..<8].withUnsafeBytes { $0.load(as: UInt32.self) })
+        guard length == 6 else { throw MidiFileParserError.invalidHeader }
+        let format = UInt16(bigEndian: data[8..<10].withUnsafeBytes { $0.load(as: UInt16.self) })
+        let trackCount = UInt16(bigEndian: data[10..<12].withUnsafeBytes { $0.load(as: UInt16.self) })
+        let division = UInt16(bigEndian: data[12..<14].withUnsafeBytes { $0.load(as: UInt16.self) })
+        return MidiFileHeader(format: format, trackCount: trackCount, division: division)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -13,7 +13,7 @@ The CLI currently supports rendering from the following source formats:
 **Pending formats** (not yet implemented):
 
 - **.storyboard**
-- **.mid / .midi** (Standard MIDI Files)
+- **.mid / .midi** (Standard MIDI Files) – header parsing implemented
 - **.ump** (Universal MIDI Packet)
 - **.session**
 
@@ -134,3 +134,7 @@ The CLI currently supports rendering from the following source formats:
 > _Maintaining clear documentation and comprehensive logging ensures long‑term reliability and ease of maintenance for the Teatro parsing subsystem._
 
 
+
+---
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+@testable import Teatro
+
+final class MidiFileParserTests: XCTestCase {
+    func testHeaderParsing() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x68, 0x64, // 'MThd'
+            0x00, 0x00, 0x00, 0x06, // length
+            0x00, 0x01,             // format 1
+            0x00, 0x02,             // track count 2
+            0x01, 0xE0              // division 480
+        ]
+        let data = Data(bytes)
+        let header = try MidiFileParser.parseHeader(data: data)
+        XCTAssertEqual(header.format, 1)
+        XCTAssertEqual(header.trackCount, 2)
+        XCTAssertEqual(header.division, 480)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- start Standard MIDI File parser with header decoding
- document parser progress and exclude parser agent doc from build
- add unit test for MIDI header parsing

## Testing
- `swift build` *(fails: header '/usr/include/csound/csound.h' not found)*
- `swift test` *(fails: header '/usr/include/csound/csound.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68901aa0b70c8325910a3e86d0446b1c