### PR TITLE
Add basic SMF track parsing

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -6,8 +6,8 @@
 - UMP rendering target is listed but missing from dispatch.
 - Environment variable precedence for width/height only applies when flags are set; no fallback to existing variables.
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
-- Tests only cover help/version output and unknown flags. `swift test` fails to compile without Csound headers.
-- Initial `MidiFileParser` parses SMF header; full track parsing remains pending.
+- Tests cover help/version output, unknown flags, and SMF header/track parsing. `swift test` fails to compile without Csound headers.
+- `MidiFileParser` parses SMF header and basic track events; additional message types remain pending.
 
 ## Action Plan
 

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -10,6 +10,8 @@ struct MidiFileHeader {
 /// Errors that can occur while parsing a Standard MIDI File.
 enum MidiFileParserError: Error {
     case invalidHeader
+    case invalidTrack
+    case invalidEvent
 }
 
 /// Parser for Standard MIDI Files (SMF).
@@ -27,6 +29,94 @@ struct MidiFileParser {
         let trackCount = UInt16(bigEndian: data[10..<12].withUnsafeBytes { $0.load(as: UInt16.self) })
         let division = UInt16(bigEndian: data[12..<14].withUnsafeBytes { $0.load(as: UInt16.self) })
         return MidiFileHeader(format: format, trackCount: trackCount, division: division)
+    }
+
+    /// Basic MIDI event representation used by `parseTrack`.
+    enum MidiEvent {
+        case noteOn(deltaTime: UInt32, channel: UInt8, note: UInt8, velocity: UInt8)
+        case noteOff(deltaTime: UInt32, channel: UInt8, note: UInt8, velocity: UInt8)
+        case meta(deltaTime: UInt32, type: UInt8, data: Data)
+    }
+
+    /// Parses a track chunk (MTrk) from a MIDI file.
+    /// - Parameter data: Data starting at the beginning of the `MTrk` chunk.
+    /// - Returns: Array of decoded `MidiEvent` values.
+    static func parseTrack(data: Data) throws -> [MidiEvent] {
+        guard data.count >= 8 else { throw MidiFileParserError.invalidTrack }
+        guard data.prefix(4) == Data([0x4D, 0x54, 0x72, 0x6B]) else { throw MidiFileParserError.invalidTrack }
+        let length = UInt32(bigEndian: data[4..<8].withUnsafeBytes { $0.load(as: UInt32.self) })
+        var index = 8
+        let end = index + Int(length)
+        var runningStatus: UInt8?
+        var events: [MidiEvent] = []
+
+        while index < end {
+            let delta = try readVariableLengthQuantity(data, index: &index)
+            guard index < end else { throw MidiFileParserError.invalidEvent }
+            var status = data[index]
+            if status < 0x80 {
+                guard let rs = runningStatus else { throw MidiFileParserError.invalidEvent }
+                status = rs
+            } else {
+                runningStatus = status
+                index += 1
+            }
+
+            let type = status & 0xF0
+            let channel = status & 0x0F
+            switch type {
+            case 0x80: // Note Off
+                guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
+                let note = data[index]
+                let velocity = data[index + 1]
+                events.append(.noteOff(deltaTime: delta, channel: channel, note: note, velocity: velocity))
+                index += 2
+            case 0x90: // Note On
+                guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
+                let note = data[index]
+                let velocity = data[index + 1]
+                events.append(.noteOn(deltaTime: delta, channel: channel, note: note, velocity: velocity))
+                index += 2
+            case 0xA0, 0xB0, 0xE0: // Two data bytes, skip
+                index += 2
+            case 0xC0, 0xD0: // One data byte, skip
+                index += 1
+            case 0xF0:
+                if status == 0xFF { // Meta event
+                    guard index < end else { throw MidiFileParserError.invalidEvent }
+                    let metaType = data[index]
+                    index += 1
+                    let length = try readVariableLengthQuantity(data, index: &index)
+                    guard index + Int(length) <= end else { throw MidiFileParserError.invalidEvent }
+                    let metaData = data[index..<index + Int(length)]
+                    events.append(.meta(deltaTime: delta, type: metaType, data: metaData))
+                    index += Int(length)
+                    if metaType == 0x2F { break } // End of track
+                } else if status == 0xF0 || status == 0xF7 { // SysEx
+                    let length = try readVariableLengthQuantity(data, index: &index)
+                    index += Int(length)
+                } else {
+                    // Other system messages ignored
+                }
+            default:
+                throw MidiFileParserError.invalidEvent
+            }
+        }
+
+        return events
+    }
+
+    /// Reads a variable-length quantity starting at `index` and advances the index.
+    private static func readVariableLengthQuantity(_ data: Data, index: inout Int) throws -> UInt32 {
+        var value: UInt32 = 0
+        while true {
+            guard index < data.count else { throw MidiFileParserError.invalidEvent }
+            let byte = data[index]
+            index += 1
+            value = (value << 7) | UInt32(byte & 0x7F)
+            if byte & 0x80 == 0 { break }
+        }
+        return value
     }
 }
 

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -13,7 +13,7 @@ The CLI currently supports rendering from the following source formats:
 **Pending formats** (not yet implemented):
 
 - **.storyboard**
-- **.mid / .midi** (Standard MIDI Files) – header parsing implemented
+ - **.mid / .midi** (Standard MIDI Files) – header and basic track parsing implemented
 - **.ump** (Universal MIDI Packet)
 - **.session**
 
@@ -21,7 +21,7 @@ The CLI currently supports rendering from the following source formats:
 > - The `ump` output target is listed in the dispatcher but has no implementation.
 > - Width/height environment variables only take effect when corresponding CLI flags are provided; no fallback behavior.
 > - Watch mode relies on a polling loop instead of using `DispatchSource.makeFileSystemObjectSource`.
-> - Tests cover only help/version output and unknown flags; `swift test` fails without Csound headers.
+> - Tests cover help/version output, unknown flags, and SMF header/track parsing; `swift test` fails without Csound headers.
 
 ---
 
@@ -116,10 +116,14 @@ The CLI currently supports rendering from the following source formats:
 ### - **Regular Status Updates**  
   - After each milestone, update the **Status Quo** section and **ImplementationPlan.md**.  
   - Report supported formats, pending work, and any caveats.
-### - **Implementation Log**  
+### - **Implementation Log**
   - Append dated entries detailing decisions, issues, resolutions, and spec references.
-### - **Issue Tracking**  
+### - **Issue Tracking**
   - Document unimplemented MIDI 2.0 messages or spec changes as TODOs in the repo and here.
+
+### Implementation Log
+
+- 2025-08-04: Added basic SMF track parsing and tests.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -17,6 +17,40 @@ final class MidiFileParserTests: XCTestCase {
         XCTAssertEqual(header.trackCount, 2)
         XCTAssertEqual(header.division, 480)
     }
+
+    func testTrackParsing() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B, // 'MTrk'
+            0x00, 0x00, 0x00, 0x15, // length 21
+            // 0 delta, meta track name "Test"
+            0x00, 0xFF, 0x03, 0x04, 0x54, 0x65, 0x73, 0x74,
+            // 0 delta, note on C4 velocity 64
+            0x00, 0x90, 0x3C, 0x40,
+            // 480 delta, note off
+            0x83, 0x60, 0x80, 0x3C, 0x40,
+            // 0 delta, end of track
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let data = Data(bytes)
+        let events = try MidiFileParser.parseTrack(data: data)
+        XCTAssertEqual(events.count, 4)
+        if case let .noteOn(delta, channel, note, velocity) = events[1] {
+            XCTAssertEqual(delta, 0)
+            XCTAssertEqual(channel, 0)
+            XCTAssertEqual(note, 0x3C)
+            XCTAssertEqual(velocity, 0x40)
+        } else {
+            XCTFail("Expected noteOn event")
+        }
+        if case let .noteOff(delta, channel, note, velocity) = events[2] {
+            XCTAssertEqual(delta, 480)
+            XCTAssertEqual(channel, 0)
+            XCTAssertEqual(note, 0x3C)
+            XCTAssertEqual(velocity, 0x40)
+        } else {
+            XCTFail("Expected noteOff event")
+        }
+    }
 }
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- expand `MidiFileParser` with basic track parsing for note and meta events
- test SMF track parsing
- update parser plan and implementation plan with progress log

## Testing
- `swift build` *(fails: header '/usr/include/csound/csound.h' not found)*
- `swift test` *(fails: could not build C module 'CCsound')*

------
https://chatgpt.com/codex/tasks/task_e_68901cd7febc8325aa94e35ace8c4729