### PR TITLE
feat: decode additional MIDI channel events

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,7 +7,7 @@
 - Environment variable precedence for width/height only applies when flags are set; no fallback to existing variables.
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
-- `MidiFileParser` parses SMF header, track events, and meta events (track name, tempo, time signature); additional message types remain pending.
+- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
 
 ## Action Plan
 

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -13,7 +13,7 @@ The CLI currently supports rendering from the following source formats:
 **Pending formats** (not yet implemented):
 
 - **.storyboard**
-- **.mid / .midi** (Standard MIDI Files) – header, track parsing, tempo and time signature meta-events implemented
+- **.mid / .midi** (Standard MIDI Files) – header, track parsing, tempo and time signature meta-events, Control Change, Program Change, and Pitch Bend events implemented
 - **.ump** (Universal MIDI Packet)
 - **.session**
 
@@ -125,6 +125,7 @@ The CLI currently supports rendering from the following source formats:
 
 - 2025-08-04: Added basic SMF track parsing and tests.
 - 2025-08-04: Added tempo and time signature meta event decoding to MidiFileParser.
+- 2025-08-04: Added Control Change, Program Change, and Pitch Bend event decoding to MidiFileParser.
 
 ---
 


### PR DESCRIPTION
## Summary
- parse Control Change, Program Change, and Pitch Bend events in `MidiFileParser`
- log parser progress for MIDI channel events
- update implementation plan with expanded SMF coverage

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890586ac52483259a132dd493c60ce5