### PR TITLE
Add initial UMP parser and update parser docs

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -8,6 +8,7 @@
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
+- Initial `UMPParser` decodes MIDI 1.0 channel voice messages; additional UMP message types remain pending.
 
 ## Action Plan
 

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Errors that can occur while parsing Universal MIDI Packet files.
+enum UMPParserError: Error {
+    case misaligned
+}
+
+/// Basic event representation for Universal MIDI Packets.
+enum UMPEvent {
+    case midi1ChannelVoice(group: UInt8, channel: UInt8, status: UInt8, data1: UInt8, data2: UInt8)
+    case unknown(group: UInt8, rawWords: [UInt32])
+}
+
+/// Parser for Universal MIDI Packet (UMP) files. This initial implementation
+/// supports decoding MIDI 1.0 channel voice messages and preserves all other
+/// packet types as opaque data.
+struct UMPParser {
+    /// Parses a UMP-formatted data stream.
+    /// - Parameter data: Raw bytes of the UMP file.
+    /// - Returns: Array of decoded `UMPEvent` values.
+    static func parse(data: Data) throws -> [UMPEvent] {
+        guard data.count % 4 == 0 else { throw UMPParserError.misaligned }
+        var events: [UMPEvent] = []
+        var index = 0
+        while index < data.count {
+            let word = data[index..<(index + 4)].withUnsafeBytes { ptr -> UInt32 in
+                return UInt32(bigEndian: ptr.load(as: UInt32.self))
+            }
+            let messageType = UInt8((word >> 28) & 0xF)
+            let group = UInt8((word >> 24) & 0xF)
+            let wordCount = packetLength(for: messageType)
+            var words = [word]
+            for i in 1..<wordCount {
+                let w = data[(index + 4 * i)..<(index + 4 * (i + 1))].withUnsafeBytes { ptr -> UInt32 in
+                    return UInt32(bigEndian: ptr.load(as: UInt32.self))
+                }
+                words.append(w)
+            }
+            events.append(decode(messageType: messageType, group: group, words: words))
+            index += wordCount * 4
+        }
+        return events
+    }
+
+    /// Determines the number of 32-bit words for a packet based on message type.
+    private static func packetLength(for messageType: UInt8) -> Int {
+        switch messageType {
+        case 0x0, 0x1, 0x2: return 1
+        case 0x4, 0x5: return 2
+        case 0x6: return 3
+        case 0x7: return 4
+        default: return 1
+        }
+    }
+
+    /// Decodes a packet into a `UMPEvent`.
+    private static func decode(messageType: UInt8, group: UInt8, words: [UInt32]) -> UMPEvent {
+        switch messageType {
+        case 0x2: // MIDI 1.0 Channel Voice Messages
+            let word = words[0]
+            let status = UInt8((word >> 20) & 0xF0)
+            let channel = UInt8((word >> 16) & 0x0F)
+            let data1 = UInt8((word >> 8) & 0x7F)
+            let data2 = UInt8(word & 0x7F)
+            return .midi1ChannelVoice(group: group, channel: channel, status: status, data1: data1, data2: data2)
+        default:
+            return .unknown(group: group, rawWords: words)
+        }
+    }
+}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -14,7 +14,7 @@ The CLI currently supports rendering from the following source formats:
 
 - **.storyboard**
 - **.mid / .midi** (Standard MIDI Files) – header, track parsing, tempo and time signature meta-events, Control Change, Program Change, and Pitch Bend events implemented
-- **.ump** (Universal MIDI Packet)
+- **.ump** (Universal MIDI Packet) – initial parser handles MIDI 1.0 channel voice messages
 - **.session**
 
 > **Open Issues**:
@@ -126,6 +126,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-04: Added basic SMF track parsing and tests.
 - 2025-08-04: Added tempo and time signature meta event decoding to MidiFileParser.
 - 2025-08-04: Added Control Change, Program Change, and Pitch Bend event decoding to MidiFileParser.
+- 2025-08-05: Added initial UMPParser with MIDI 1.0 channel voice message decoding.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `UMPParser` to decode Universal MIDI Packet streams and handle MIDI 1.0 channel voice messages
- Log UMP parser progress in parser agent plan and implementation plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689059b9d69c8325ab923e0fd04be3fa