### PR TITLE
Support UMP system messages

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -8,7 +8,7 @@
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
-- Initial `UMPParser` decodes MIDI 1.0 channel voice messages; additional UMP message types remain pending.
+- `UMPParser` decodes system real-time/common messages and MIDI 1.0 channel voice messages; additional UMP message types remain pending.
 
 ## Action Plan
 

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -127,6 +127,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-04: Added tempo and time signature meta event decoding to MidiFileParser.
 - 2025-08-04: Added Control Change, Program Change, and Pitch Bend event decoding to MidiFileParser.
 - 2025-08-05: Added initial UMPParser with MIDI 1.0 channel voice message decoding.
+- 2025-08-06: Added system real-time/common message decoding to UMPParser and unit tests.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Teatro
+
+final class UMPParserTests: XCTestCase {
+    func testMIDI1ChannelVoiceDecoding() throws {
+        let bytes: [UInt8] = [0x20, 0x90, 0x3C, 0x40]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard case let .midi1ChannelVoice(group, channel, status, data1, data2) = events.first else {
+            return XCTFail("Expected midi1ChannelVoice event")
+        }
+        XCTAssertEqual(group, 0)
+        XCTAssertEqual(channel, 0)
+        XCTAssertEqual(status, 0x90)
+        XCTAssertEqual(data1, 0x3C)
+        XCTAssertEqual(data2, 0x40)
+    }
+
+    func testSystemMessageDecoding() throws {
+        let bytes: [UInt8] = [0x12, 0xF8, 0x00, 0x00]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard case let .systemMessage(group, status, data1, data2) = events.first else {
+            return XCTFail("Expected systemMessage event")
+        }
+        XCTAssertEqual(group, 2)
+        XCTAssertEqual(status, 0xF8)
+        XCTAssertEqual(data1, 0)
+        XCTAssertEqual(data2, 0)
+    }
+
+    func testUnknownPacketPreserved() throws {
+        let bytes: [UInt8] = [
+            0x40, 0x00, 0x00, 0x00,
+            0x01, 0x02, 0x03, 0x04
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard case let .unknown(group, rawWords) = events.first else {
+            return XCTFail("Expected unknown event")
+        }
+        XCTAssertEqual(group, 0)
+        XCTAssertEqual(rawWords.count, 2)
+        XCTAssertEqual(rawWords[0], 0x40000000)
+        XCTAssertEqual(rawWords[1], 0x01020304)
+    }
+
+    func testMisalignedDataThrows() {
+        let bytes: [UInt8] = [0x00]
+        XCTAssertThrowsError(try UMPParser.parse(data: Data(bytes))) { error in
+            guard case UMPParserError.misaligned = error else {
+                return XCTFail("Expected misaligned error")
+            }
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- parse UMP system real-time/common packets and expose them via a new `systemMessage` event
- add unit tests for UMPParser covering system messages, channel voice packets, unknown packets and misalignment errors
- record progress in parser agent docs and implementation plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68905b256944832587df16499fd12542