### PR TITLE
Expand UMP parser with utility message support

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -8,7 +8,7 @@
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
-- `UMPParser` decodes system real-time/common messages and MIDI 1.0 channel voice messages; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, and MIDI 1.0 channel voice messages; additional UMP message types remain pending.
 
 ## Action Plan
 

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -7,6 +7,7 @@ enum UMPParserError: Error {
 
 /// Basic event representation for Universal MIDI Packets.
 enum UMPEvent {
+    case utilityMessage(group: UInt8, status: UInt8, data1: UInt8, data2: UInt8)
     case systemMessage(group: UInt8, status: UInt8, data1: UInt8, data2: UInt8)
     case midi1ChannelVoice(group: UInt8, channel: UInt8, status: UInt8, data1: UInt8, data2: UInt8)
     case unknown(group: UInt8, rawWords: [UInt32])
@@ -57,6 +58,12 @@ struct UMPParser {
     /// Decodes a packet into a `UMPEvent`.
     private static func decode(messageType: UInt8, group: UInt8, words: [UInt32]) -> UMPEvent {
         switch messageType {
+        case 0x0: // Utility Messages
+            let word = words[0]
+            let status = UInt8((word >> 16) & 0xFF)
+            let data1 = UInt8((word >> 8) & 0xFF)
+            let data2 = UInt8(word & 0xFF)
+            return .utilityMessage(group: group, status: status, data1: data1, data2: data2)
         case 0x1: // System Real-Time and System Common Messages
             let word = words[0]
             let status = UInt8((word >> 16) & 0xFF)

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -14,7 +14,7 @@ The CLI currently supports rendering from the following source formats:
 
 - **.storyboard**
 - **.mid / .midi** (Standard MIDI Files) – header, track parsing, tempo and time signature meta-events, Control Change, Program Change, and Pitch Bend events implemented
-- **.ump** (Universal MIDI Packet) – initial parser handles MIDI 1.0 channel voice messages
+- **.ump** (Universal MIDI Packet) – parser handles MIDI 1.0 channel voice, system real-time/common, and utility messages
 - **.session**
 
 > **Open Issues**:
@@ -128,6 +128,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-04: Added Control Change, Program Change, and Pitch Bend event decoding to MidiFileParser.
 - 2025-08-05: Added initial UMPParser with MIDI 1.0 channel voice message decoding.
 - 2025-08-06: Added system real-time/common message decoding to UMPParser and unit tests.
+- 2025-08-07: Added utility message decoding to UMPParser and unit tests.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -2,6 +2,18 @@ import XCTest
 @testable import Teatro
 
 final class UMPParserTests: XCTestCase {
+    func testUtilityMessageDecoding() throws {
+        let bytes: [UInt8] = [0x02, 0x7F, 0xAA, 0xBB]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard case let .utilityMessage(group, status, data1, data2) = events.first else {
+            return XCTFail("Expected utilityMessage event")
+        }
+        XCTAssertEqual(group, 2)
+        XCTAssertEqual(status, 0x7F)
+        XCTAssertEqual(data1, 0xAA)
+        XCTAssertEqual(data2, 0xBB)
+    }
+
     func testMIDI1ChannelVoiceDecoding() throws {
         let bytes: [UInt8] = [0x20, 0x90, 0x3C, 0x40]
         let events = try UMPParser.parse(data: Data(bytes))


### PR DESCRIPTION
## Summary
- handle UMP utility messages and expose them via a new `utilityMessage` event
- cover utility message parsing with new test cases
- document parser progress in ImplementationPlan and parser agent log

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68905cb1bc7483259dbe4170b9632990