### PR TITLE
Handle truncated UMP packets

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -8,7 +8,7 @@
 - Watch mode uses a polling loop rather than `DispatchSource.makeFileSystemObjectSource`.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
-- `UMPParser` decodes utility, system real-time/common, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Errors that can occur while parsing Universal MIDI Packet files.
 enum UMPParserError: Error {
     case misaligned
+    case truncated
 }
 
 /// Parser for Universal MIDI Packet (UMP) files. This implementation supports
@@ -24,6 +25,9 @@ struct UMPParser {
             let messageType = UInt8((word >> 28) & 0xF)
             let group = UInt8((word >> 24) & 0xF)
             let wordCount = packetLength(for: messageType)
+            guard index + wordCount * 4 <= data.count else {
+                throw UMPParserError.truncated
+            }
             var words = [word]
             for i in 1..<wordCount {
                 let w = data[(index + 4 * i)..<(index + 4 * (i + 1))].withUnsafeBytes { ptr -> UInt32 in

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -132,6 +132,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-08: Added MIDI 2.0 channel voice message decoding to UMPParser and unit tests.
 - 2025-08-09: Added width/height environment variable fallback in RenderCLI.
 - 2025-08-10: Introduced unified MIDI event model and updated SMF/UMP parsers.
+- 2025-08-11: Added truncated packet error handling to UMPParser and tests.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -67,6 +67,16 @@ final class UMPParserTests: XCTestCase {
             }
         }
     }
+
+    func testTruncatedPacketThrows() {
+        // Message type 0x4 requires two words but only one is provided
+        let bytes: [UInt8] = [0x40, 0x90, 0x3C, 0x00]
+        XCTAssertThrowsError(try UMPParser.parse(data: Data(bytes))) { error in
+            guard case UMPParserError.truncated = error else {
+                return XCTFail("Expected truncated error")
+            }
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- validate UMP parsing against truncated packets
- document UMP parser packet validation in implementation plan and agent log

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890643775a88325abe768911859f42d