### PR TITLE
feat: add placeholder UMP output

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -3,7 +3,7 @@
 ## Status Quo
 
 - CLI handles `.fountain`, `.ly`, and `.csd` inputs; `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` inputs remain unimplemented, though MIDI and UMP files are now detected by signature.
-- UMP rendering target is listed but missing from dispatch.
+- UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
@@ -14,7 +14,7 @@
 ## Action Plan
 
 1. Implement parsers and renderers for `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` files (SMF header parser implemented).
-2. Add `ump` output target in the render dispatcher and ensure all formats are documented.
+2. ~~Add `ump` output target in the render dispatcher and ensure all formats are documented.~~
 3. ~~Apply environment variable fallback when width/height flags are absent and add tests for precedence.~~
 4. ~~Replace polling watch mode with `DispatchSource.makeFileSystemObjectSource` on platforms that support it.~~
 5. Expand test suite to cover argument parsing, watch/dispatch logic, output correctness, and environment variable precedence.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -26,7 +26,7 @@ The CLI currently supports rendering from the following source formats:
 - **.session**
 
 > **Open Issues**:
-> - The `ump` output target is listed in the dispatcher but has no implementation.
+> - The `ump` output target now emits a placeholder UMP packet; full renderer integration is pending.
 > - Tests cover help/version output, unknown flags, and SMF header/track parsing; Csound and FluidSynth headers are optional via conditional compilation.
 
 ---
@@ -141,6 +141,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-11: Added truncated packet error handling to UMPParser and tests.
 - 2025-08-12: Replaced CLI watch mode polling with DispatchSource-based file monitoring on supported platforms.
 - 2025-08-13: Added file signature detection for MIDI and UMP inputs in RenderCLI.
+- 2025-08-14: Added placeholder UMP rendering output target in RenderCLI.
 
 ---
 

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -78,6 +78,15 @@ final class RenderCLITests: XCTestCase {
             }
         }
     }
+
+    func testUMPOutputWritesFile() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("out.ump")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cli = try RenderCLI.parse(["--format", "ump", "--output", url.path])
+        try cli.run()
+        let data = try Data(contentsOf: url)
+        XCTAssertEqual(data.count, 8)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add placeholder UMP rendering that encodes a single MIDI 2.0 note
- document UMP output target in implementation plan and parser roadmap
- test writing UMP output files via CLI

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68906b1db2a08325ae95c550de9b996b