### PR TITLE
Map UMP groups into unified channel numbers

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -8,7 +8,7 @@
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
-- `UMPParser` decodes utility, system real-time/common, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages and validates misaligned or truncated packets; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -58,7 +58,7 @@ struct UMPParser {
         case 0x2: // MIDI 1.0 Channel Voice Messages
             let word = words[0]
             let status = UInt8(((word >> 20) & 0x0F) << 4)
-            let channel = UInt8((word >> 16) & 0x0F)
+            let channel = UInt8((group << 4) | UInt8((word >> 16) & 0x0F))
             let data1 = UInt8((word >> 8) & 0x7F)
             let data2 = UInt8(word & 0x7F)
             switch status {
@@ -79,7 +79,7 @@ struct UMPParser {
         case 0x4: // MIDI 2.0 Channel Voice Messages
             let word1 = words[0]
             let status = UInt8(((word1 >> 20) & 0x0F) << 4)
-            let channel = UInt8((word1 >> 16) & 0x0F)
+            let channel = UInt8((group << 4) | UInt8((word1 >> 16) & 0x0F))
             let data1 = UInt16(word1 & 0xFFFF)
             let data2 = words.count > 1 ? words[1] : 0
             switch status {

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -47,6 +47,16 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.velocity, 0x7F)
     }
 
+    func testGroupChannelMapping() throws {
+        // Group 2, channel 10 should map to unified channel 42
+        let bytes: [UInt8] = [0x22, 0x9A, 0x3C, 0x40]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.channel, 0x2A)
+    }
+
     func testUnknownPacketPreserved() throws {
         let bytes: [UInt8] = [
             0x50, 0x00, 0x00, 0x00,


### PR DESCRIPTION
## Summary
- combine UMP group and channel nibbles into unified channel indices for both MIDI 1.0 and MIDI 2.0 packets
- document group-to-channel mapping in implementation plan
- cover group/channel mapping with unit test

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68906cb60d0c8325b609c3f758b00254