### PR TITLE
Handle SysEx UMP packets

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -8,7 +8,7 @@
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
-- `UMPParser` decodes utility, system real-time/common, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -98,6 +98,8 @@ struct UMPParser {
             default:
                 return UnknownEvent(timestamp: 0, data: rawData(from: words))
             }
+        case 0x5, 0x6: // SysEx7 and SysEx8
+            return SysExEvent(timestamp: 0, data: rawData(from: words))
         default:
             return UnknownEvent(timestamp: 0, data: rawData(from: words))
         }

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -142,6 +142,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-12: Replaced CLI watch mode polling with DispatchSource-based file monitoring on supported platforms.
 - 2025-08-13: Added file signature detection for MIDI and UMP inputs in RenderCLI.
 - 2025-08-14: Added placeholder UMP rendering output target in RenderCLI.
+- 2025-08-15: Added SysEx7 and SysEx8 message decoding to UMPParser and unit tests.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -47,6 +47,18 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.velocity, 0x7F)
     }
 
+    func testSysEx7Decoding() throws {
+        let bytes: [UInt8] = [
+            0x50, 0x00, 0x12, 0x34,
+            0x56, 0x78, 0x9A, 0xBC
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? SysExEvent else {
+            return XCTFail("Expected SysExEvent")
+        }
+        XCTAssertEqual(event.rawData, Data(bytes))
+    }
+
     func testGroupChannelMapping() throws {
         // Group 2, channel 10 should map to unified channel 42
         let bytes: [UInt8] = [0x22, 0x9A, 0x3C, 0x40]
@@ -59,8 +71,10 @@ final class UMPParserTests: XCTestCase {
 
     func testUnknownPacketPreserved() throws {
         let bytes: [UInt8] = [
-            0x50, 0x00, 0x00, 0x00,
-            0x01, 0x02, 0x03, 0x04
+            0x70, 0x00, 0x00, 0x00,
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0A, 0x0B, 0x0C
         ]
         let events = try UMPParser.parse(data: Data(bytes))
         guard let event = events.first as? UnknownEvent else {


### PR DESCRIPTION
## Summary
- parse SysEx7 and SysEx8 packet types in the UMP parser
- verify SysEx7 handling and preserve unhandled packet types in UMP parser tests
- note SysEx support in the implementation plan and parser agent log

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68906f0ff08c83259c27d3369dd247e6