### PR TITLE
Handle channel pressure in MIDI parsers

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,8 +7,8 @@
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
-- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend), and meta events (track name, tempo, time signature); remaining message types remain pending.
-- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 channel voice, and MIDI 2.0 channel voice messages, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+ - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
+ - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Channel Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/MidiEvents.swift
+++ b/Sources/Parsers/MidiEvents.swift
@@ -7,6 +7,7 @@ enum MidiEventType {
     case controlChange
     case programChange
     case pitchBend
+    case channelPressure
     case meta
     case sysEx
     case unknown

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -90,7 +90,10 @@ struct MidiFileParser {
                 index += 2
             case 0xA0: // Polyphonic Key Pressure - ignore contents
                 index += 2
-            case 0xD0: // Channel Pressure - ignore contents
+            case 0xD0: // Channel Pressure
+                guard index < end else { throw MidiFileParserError.invalidEvent }
+                let pressure = data[index]
+                events.append(ChannelVoiceEvent(timestamp: delta, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(pressure)))
                 index += 1
             case 0xF0:
                 if status == 0xFF { // Meta event

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -73,6 +73,8 @@ struct UMPParser {
             case 0xE0:
                 let value = UInt32((UInt16(data2) << 7) | UInt16(data1))
                 return ChannelVoiceEvent(timestamp: 0, type: .pitchBend, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: value)
+            case 0xD0:
+                return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(data1))
             default:
                 return UnknownEvent(timestamp: 0, data: rawData(from: words))
             }
@@ -95,6 +97,8 @@ struct UMPParser {
                 let controller = UInt8((data1 >> 8) & 0xFF)
                 let value = ChannelVoiceEvent.normalizeController(data2)
                 return ChannelVoiceEvent(timestamp: 0, type: .controlChange, channelNumber: channel, noteNumber: controller, velocity: nil, controllerValue: UInt32(value))
+            case 0xD0:
+                return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
             default:
                 return UnknownEvent(timestamp: 0, data: rawData(from: words))
             }

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -143,6 +143,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-13: Added file signature detection for MIDI and UMP inputs in RenderCLI.
 - 2025-08-14: Added placeholder UMP rendering output target in RenderCLI.
 - 2025-08-15: Added SysEx7 and SysEx8 message decoding to UMPParser and unit tests.
+- 2025-08-16: Added channel pressure decoding to MidiFileParser and UMPParser.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -47,6 +47,24 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.velocity, 0x7F)
     }
 
+    func testChannelPressureDecoding() throws {
+        let midi1: [UInt8] = [0x20, 0xD0, 0x40, 0x00]
+        let midi2: [UInt8] = [
+            0x40, 0xD0, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x80
+        ]
+        let events1 = try UMPParser.parse(data: Data(midi1))
+        let events2 = try UMPParser.parse(data: Data(midi2))
+        guard let e1 = events1.first as? ChannelVoiceEvent,
+              let e2 = events2.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(e1.type, .channelPressure)
+        XCTAssertEqual(e1.controllerValue, 0x40)
+        XCTAssertEqual(e2.type, .channelPressure)
+        XCTAssertEqual(e2.controllerValue, 0x00000080)
+    }
+
     func testSysEx7Decoding() throws {
         let bytes: [UInt8] = [
             0x50, 0x00, 0x12, 0x34,

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -86,5 +86,23 @@ final class MidiFileParserTests: XCTestCase {
             XCTFail("Expected ChannelVoiceEvent noteOff")
         }
     }
+
+    func testChannelPressureDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x07,
+            0x00, 0xD0, 0x40,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let pressure = events[0] as? ChannelVoiceEvent {
+            XCTAssertEqual(pressure.type, .channelPressure)
+            XCTAssertEqual(pressure.channel, 0)
+            XCTAssertEqual(pressure.controllerValue, 0x40)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent channelPressure")
+        }
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support channel pressure events in MidiFileParser and UMPParser
- cover new event with unit tests
- record progress in parser agent plan and implementation docs

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689070b2777c83259e22c64f7bae1eee