### PR TITLE
Add polyphonic key pressure parsing

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,8 +7,8 @@
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
- - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
- - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Channel Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+ - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
+ - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Channel Pressure and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/MidiEvents.swift
+++ b/Sources/Parsers/MidiEvents.swift
@@ -8,6 +8,7 @@ enum MidiEventType {
     case programChange
     case pitchBend
     case channelPressure
+    case polyphonicKeyPressure
     case meta
     case sysEx
     case unknown

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -88,7 +88,11 @@ struct MidiFileParser {
                 let value = (msb << 7) | lsb
                 events.append(ChannelVoiceEvent(timestamp: delta, type: .pitchBend, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(value)))
                 index += 2
-            case 0xA0: // Polyphonic Key Pressure - ignore contents
+            case 0xA0: // Polyphonic Key Pressure
+                guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
+                let note = data[index]
+                let pressure = data[index + 1]
+                events.append(ChannelVoiceEvent(timestamp: delta, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: note, velocity: pressure, controllerValue: nil))
                 index += 2
             case 0xD0: // Channel Pressure
                 guard index < end else { throw MidiFileParserError.invalidEvent }

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -66,6 +66,8 @@ struct UMPParser {
                 return ChannelVoiceEvent(timestamp: 0, type: .noteOff, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0x90:
                 return ChannelVoiceEvent(timestamp: 0, type: .noteOn, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
+            case 0xA0:
+                return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0xB0:
                 return ChannelVoiceEvent(timestamp: 0, type: .controlChange, channelNumber: channel, noteNumber: data1, velocity: nil, controllerValue: UInt32(data2))
             case 0xC0:
@@ -93,6 +95,10 @@ struct UMPParser {
                 let note = UInt8((data1 >> 8) & 0xFF)
                 let vel = ChannelVoiceEvent.normalizeVelocity(UInt16((data2 >> 16) & 0xFFFF))
                 return ChannelVoiceEvent(timestamp: 0, type: .noteOn, channelNumber: channel, noteNumber: note, velocity: vel, controllerValue: nil)
+            case 0xA0:
+                let note = UInt8((data1 >> 8) & 0xFF)
+                let pressure = ChannelVoiceEvent.normalizeController(data2)
+                return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: note, velocity: pressure, controllerValue: nil)
             case 0xB0:
                 let controller = UInt8((data1 >> 8) & 0xFF)
                 let value = ChannelVoiceEvent.normalizeController(data2)

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -144,6 +144,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-14: Added placeholder UMP rendering output target in RenderCLI.
 - 2025-08-15: Added SysEx7 and SysEx8 message decoding to UMPParser and unit tests.
 - 2025-08-16: Added channel pressure decoding to MidiFileParser and UMPParser.
+- 2025-08-17: Added polyphonic key pressure decoding to MidiFileParser and UMPParser.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -65,6 +65,26 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(e2.controllerValue, 0x00000080)
     }
 
+    func testPolyphonicKeyPressureDecoding() throws {
+        let midi1: [UInt8] = [0x20, 0xA0, 0x3C, 0x40]
+        let midi2: [UInt8] = [
+            0x40, 0xA0, 0x3C, 0x00,
+            0x40, 0x00, 0x00, 0x00
+        ]
+        let events1 = try UMPParser.parse(data: Data(midi1))
+        let events2 = try UMPParser.parse(data: Data(midi2))
+        guard let e1 = events1.first as? ChannelVoiceEvent,
+              let e2 = events2.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(e1.type, .polyphonicKeyPressure)
+        XCTAssertEqual(e1.noteNumber, 0x3C)
+        XCTAssertEqual(e1.velocity, 0x40)
+        XCTAssertEqual(e2.type, .polyphonicKeyPressure)
+        XCTAssertEqual(e2.noteNumber, 0x3C)
+        XCTAssertEqual(e2.velocity, 0x40)
+    }
+
     func testSysEx7Decoding() throws {
         let bytes: [UInt8] = [
             0x50, 0x00, 0x12, 0x34,

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -104,5 +104,24 @@ final class MidiFileParserTests: XCTestCase {
             XCTFail("Expected ChannelVoiceEvent channelPressure")
         }
     }
+
+    func testPolyphonicKeyPressureDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x08,
+            0x00, 0xA0, 0x3C, 0x40,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let pressure = events[0] as? ChannelVoiceEvent {
+            XCTAssertEqual(pressure.type, .polyphonicKeyPressure)
+            XCTAssertEqual(pressure.channel, 0)
+            XCTAssertEqual(pressure.noteNumber, 0x3C)
+            XCTAssertEqual(pressure.velocity, 0x40)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent polyphonicKeyPressure")
+        }
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support polyphonic key pressure in MIDI event type
- decode polyphonic key pressure in Standard MIDI File and UMP parsers
- document and test the new polyphonic key pressure support

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890730fbcc08325810aca161994316c