### PR TITLE
test: verify unknown meta event preservation

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,8 +7,9 @@
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
- - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
- - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Channel Pressure and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
+- Unknown meta events are preserved and unit tests verify this behavior.
+- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Channel Pressure and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -145,6 +145,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-15: Added SysEx7 and SysEx8 message decoding to UMPParser and unit tests.
 - 2025-08-16: Added channel pressure decoding to MidiFileParser and UMPParser.
 - 2025-08-17: Added polyphonic key pressure decoding to MidiFileParser and UMPParser.
+- 2025-08-18: Added unit test verifying preservation of unknown meta events in MidiFileParser.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -123,5 +123,22 @@ final class MidiFileParserTests: XCTestCase {
             XCTFail("Expected ChannelVoiceEvent polyphonicKeyPressure")
         }
     }
+
+    func testUnknownMetaEventPreserved() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x09,
+            0x00, 0xFF, 0x7F, 0x01, 0x42,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let meta = events[0] as? MetaEvent {
+            XCTAssertEqual(meta.metaType, 0x7F)
+            XCTAssertEqual(meta.rawData, Data([0x42]))
+        } else {
+            XCTFail("Expected MetaEvent with type 0x7F")
+        }
+    }
 }
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add regression test ensuring MidiFileParser preserves unknown meta events
- document parser capability in implementation plan and parser agent log

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689074fb61608325839db265e770e5fb