### PR TITLE
Support MIDI 2.0 program change and pitch bend

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -9,7 +9,7 @@
 - Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events are preserved and unit tests verify this behavior.
-- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Channel Pressure and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -103,8 +103,13 @@ struct UMPParser {
                 let controller = UInt8((data1 >> 8) & 0xFF)
                 let value = ChannelVoiceEvent.normalizeController(data2)
                 return ChannelVoiceEvent(timestamp: 0, type: .controlChange, channelNumber: channel, noteNumber: controller, velocity: nil, controllerValue: UInt32(value))
+            case 0xC0:
+                let program = UInt8((data2 >> 24) & 0x7F)
+                return ChannelVoiceEvent(timestamp: 0, type: .programChange, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(program))
             case 0xD0:
                 return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
+            case 0xE0:
+                return ChannelVoiceEvent(timestamp: 0, type: .pitchBend, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
             default:
                 return UnknownEvent(timestamp: 0, data: rawData(from: words))
             }

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -146,6 +146,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-16: Added channel pressure decoding to MidiFileParser and UMPParser.
 - 2025-08-17: Added polyphonic key pressure decoding to MidiFileParser and UMPParser.
 - 2025-08-18: Added unit test verifying preservation of unknown meta events in MidiFileParser.
+- 2025-08-19: Added MIDI 2.0 Program Change and Pitch Bend decoding to UMPParser and unit tests.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -47,6 +47,34 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.velocity, 0x7F)
     }
 
+    func testMIDI2ProgramChangeDecoding() throws {
+        let bytes: [UInt8] = [
+            0x40, 0xC0, 0x00, 0x00,
+            0x05, 0x00, 0x00, 0x00
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.type, .programChange)
+        XCTAssertEqual(event.channel, 0)
+        XCTAssertEqual(event.controllerValue, 0x05)
+    }
+
+    func testMIDI2PitchBendDecoding() throws {
+        let bytes: [UInt8] = [
+            0x40, 0xE0, 0x00, 0x00,
+            0x00, 0x01, 0x00, 0x00
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.type, .pitchBend)
+        XCTAssertEqual(event.channel, 0)
+        XCTAssertEqual(event.controllerValue, 0x00010000)
+    }
+
     func testChannelPressureDecoding() throws {
         let midi1: [UInt8] = [0x20, 0xD0, 0x40, 0x00]
         let midi2: [UInt8] = [


### PR DESCRIPTION
## Summary
- handle MIDI 2.0 Program Change and Pitch Bend messages in `UMPParser`
- cover new MIDI 2.0 cases with parser tests
- log parser updates and refresh docs implementation status

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689078a45e108325b9d006dec35dbdbb