### PR TITLE
Add program change and pitch bend decoding tests for SMF parser

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -6,7 +6,7 @@
 - UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
-- Tests cover help/version output, unknown flags, and SMF header/track parsing. Csound and FluidSynth headers are vendored for consistent builds.
+- Tests cover help/version output, unknown flags, and SMF header/track parsing (including Program Change and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events are preserved and unit tests verify this behavior.
 - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -147,6 +147,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-17: Added polyphonic key pressure decoding to MidiFileParser and UMPParser.
 - 2025-08-18: Added unit test verifying preservation of unknown meta events in MidiFileParser.
 - 2025-08-19: Added MIDI 2.0 Program Change and Pitch Bend decoding to UMPParser and unit tests.
+- 2025-08-20: Added Program Change and Pitch Bend decoding tests to MidiFileParser.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -124,6 +124,42 @@ final class MidiFileParserTests: XCTestCase {
         }
     }
 
+    func testProgramChangeDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x07,
+            0x00, 0xC0, 0x05,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let program = events[0] as? ChannelVoiceEvent {
+            XCTAssertEqual(program.type, .programChange)
+            XCTAssertEqual(program.channel, 0)
+            XCTAssertEqual(program.controllerValue, 0x05)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent programChange")
+        }
+    }
+
+    func testPitchBendDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x08,
+            0x00, 0xE0, 0x00, 0x40,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let bend = events[0] as? ChannelVoiceEvent {
+            XCTAssertEqual(bend.type, .pitchBend)
+            XCTAssertEqual(bend.channel, 0)
+            XCTAssertEqual(bend.controllerValue, 0x2000)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent pitchBend")
+        }
+    }
+
     func testUnknownMetaEventPreserved() throws {
         let bytes: [UInt8] = [
             0x4D, 0x54, 0x72, 0x6B,


### PR DESCRIPTION
## Summary
- test program change and pitch bend events in SMF parser
- document expanded parser test coverage
- record parser test addition in parser agent log

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68907ba7a7d88325933c05ceb554434c