### PR TITLE
Normalize zero-velocity note-on events

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,9 +7,9 @@
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing (including Program Change and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
-- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), and meta events (track name, tempo, time signature); remaining message types remain pending.
+- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), normalizing Note On events with velocity 0 to Note Off, and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events are preserved and unit tests verify this behavior.
-- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure), maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -64,11 +64,12 @@ struct MidiFileParser {
                 let velocity = data[index + 1]
                 events.append(ChannelVoiceEvent(timestamp: delta, type: .noteOff, channelNumber: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
                 index += 2
-            case 0x90: // Note On
+            case 0x90: // Note On (velocity 0 treated as Note Off)
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
                 let note = data[index]
                 let velocity = data[index + 1]
-                events.append(ChannelVoiceEvent(timestamp: delta, type: .noteOn, channelNumber: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
+                let eventType: MidiEventType = velocity == 0 ? .noteOff : .noteOn
+                events.append(ChannelVoiceEvent(timestamp: delta, type: eventType, channelNumber: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
                 index += 2
             case 0xB0: // Control Change
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -65,7 +65,8 @@ struct UMPParser {
             case 0x80:
                 return ChannelVoiceEvent(timestamp: 0, type: .noteOff, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0x90:
-                return ChannelVoiceEvent(timestamp: 0, type: .noteOn, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
+                let eventType: MidiEventType = data2 == 0 ? .noteOff : .noteOn
+                return ChannelVoiceEvent(timestamp: 0, type: eventType, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0xA0:
                 return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0xB0:

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -148,6 +148,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-18: Added unit test verifying preservation of unknown meta events in MidiFileParser.
 - 2025-08-19: Added MIDI 2.0 Program Change and Pitch Bend decoding to UMPParser and unit tests.
 - 2025-08-20: Added Program Change and Pitch Bend decoding tests to MidiFileParser.
+- 2025-08-21: Treat Note On with velocity 0 as Note Off in MidiFileParser and UMPParser.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -23,6 +23,17 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.velocity, 0x40)
     }
 
+    func testMIDI1NoteOnZeroVelocityTreatedAsNoteOff() throws {
+        let bytes: [UInt8] = [0x20, 0x90, 0x3C, 0x00]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.type, .noteOff)
+        XCTAssertEqual(event.noteNumber, 0x3C)
+        XCTAssertEqual(event.velocity, 0)
+    }
+
     func testSystemMessageDecoding() throws {
         let bytes: [UInt8] = [0x12, 0xF8, 0x00, 0x00]
         let events = try UMPParser.parse(data: Data(bytes))

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -160,6 +160,24 @@ final class MidiFileParserTests: XCTestCase {
         }
     }
 
+    func testNoteOnZeroVelocityTreatedAsNoteOff() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x08,
+            0x00, 0x90, 0x3C, 0x00,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let note = events[0] as? ChannelVoiceEvent {
+            XCTAssertEqual(note.type, .noteOff)
+            XCTAssertEqual(note.velocity, 0)
+            XCTAssertEqual(note.noteNumber, 0x3C)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent noteOff")
+        }
+    }
+
     func testUnknownMetaEventPreserved() throws {
         let bytes: [UInt8] = [
             0x4D, 0x54, 0x72, 0x6B,


### PR DESCRIPTION
## Summary
- treat note-on with velocity 0 as note-off in SMF and UMP parsers
- expand parser tests for zero-velocity note-on behavior
- document the change in parser agent log and implementation plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68907d8dcfa08325aea2ebc37dafe319