### PR TITLE
test: cover MIDI control change events

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -6,7 +6,7 @@
 - UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
-- Tests cover help/version output, unknown flags, and SMF header/track parsing (including Program Change and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
+- Tests cover help/version output, unknown flags, and SMF header/track parsing (including Control Change, Program Change, and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), normalizing Note On events with velocity 0 to Note Off, and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events are preserved and unit tests verify this behavior.
 - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -149,6 +149,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-19: Added MIDI 2.0 Program Change and Pitch Bend decoding to UMPParser and unit tests.
 - 2025-08-20: Added Program Change and Pitch Bend decoding tests to MidiFileParser.
 - 2025-08-21: Treat Note On with velocity 0 as Note Off in MidiFileParser and UMPParser.
+- 2025-08-22: Added Control Change decoding tests for MidiFileParser and UMPParser.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -124,6 +124,26 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(e2.velocity, 0x40)
     }
 
+    func testControlChangeDecoding() throws {
+        let midi1: [UInt8] = [0x20, 0xB0, 0x07, 0x40]
+        let midi2: [UInt8] = [
+            0x40, 0xB0, 0x07, 0x00,
+            0x40, 0x00, 0x00, 0x00
+        ]
+        let events1 = try UMPParser.parse(data: Data(midi1))
+        let events2 = try UMPParser.parse(data: Data(midi2))
+        guard let e1 = events1.first as? ChannelVoiceEvent,
+              let e2 = events2.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(e1.type, .controlChange)
+        XCTAssertEqual(e1.noteNumber, 0x07)
+        XCTAssertEqual(e1.controllerValue, 0x40)
+        XCTAssertEqual(e2.type, .controlChange)
+        XCTAssertEqual(e2.noteNumber, 0x07)
+        XCTAssertEqual(e2.controllerValue, 0x40)
+    }
+
     func testSysEx7Decoding() throws {
         let bytes: [UInt8] = [
             0x50, 0x00, 0x12, 0x34,

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -124,6 +124,25 @@ final class MidiFileParserTests: XCTestCase {
         }
     }
 
+    func testControlChangeDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x08,
+            0x00, 0xB0, 0x07, 0x40,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let cc = events[0] as? ChannelVoiceEvent {
+            XCTAssertEqual(cc.type, .controlChange)
+            XCTAssertEqual(cc.channel, 0)
+            XCTAssertEqual(cc.noteNumber, 0x07)
+            XCTAssertEqual(cc.controllerValue, 0x40)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent controlChange")
+        }
+    }
+
     func testProgramChangeDecoding() throws {
         let bytes: [UInt8] = [
             0x4D, 0x54, 0x72, 0x6B,


### PR DESCRIPTION
## Summary
- test SMF control change parsing
- test UMP control change parsing
- note new test coverage in parser docs and plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890851ea1808325930652eaef34b3e8