### PR TITLE
test: verify running status decoding

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -6,8 +6,8 @@
 - UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
-- Tests cover help/version output, unknown flags, and SMF header/track parsing (including Control Change, Program Change, and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
-- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), normalizing Note On events with velocity 0 to Note Off, and meta events (track name, tempo, time signature); remaining message types remain pending.
+- Tests cover help/version output, unknown flags, and SMF header/track parsing (including running status, Control Change, Program Change, and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
+- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), handles running status, normalizes Note On events with velocity 0 to Note Off, and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events are preserved and unit tests verify this behavior.
 - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -150,6 +150,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-20: Added Program Change and Pitch Bend decoding tests to MidiFileParser.
 - 2025-08-21: Treat Note On with velocity 0 as Note Off in MidiFileParser and UMPParser.
 - 2025-08-22: Added Control Change decoding tests for MidiFileParser and UMPParser.
+- 2025-08-23: Added running status decoding test to MidiFileParser.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -179,6 +179,27 @@ final class MidiFileParserTests: XCTestCase {
         }
     }
 
+    func testRunningStatusDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x0B,
+            0x00, 0x90, 0x3C, 0x40,
+            0x00, 0x40, 0x40,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 3)
+        if let first = events[0] as? ChannelVoiceEvent,
+           let second = events[1] as? ChannelVoiceEvent {
+            XCTAssertEqual(first.type, .noteOn)
+            XCTAssertEqual(first.noteNumber, 0x3C)
+            XCTAssertEqual(second.type, .noteOn)
+            XCTAssertEqual(second.noteNumber, 0x40)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent noteOn events")
+        }
+    }
+
     func testNoteOnZeroVelocityTreatedAsNoteOff() throws {
         let bytes: [UInt8] = [
             0x4D, 0x54, 0x72, 0x6B,


### PR DESCRIPTION
## Summary
- test SMF running status decoding in `MidiFileParser`
- document running status support in implementation plan
- log running status test addition in parser agent plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689087985d7483259ef3d655ac9073e2