### PR TITLE
Add SysEx event test for MidiFileParser

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -7,8 +7,8 @@
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, and SMF header/track parsing (including running status, Control Change, Program Change, and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
-- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), handles running status, normalizes Note On events with velocity 0 to Note Off, and meta events (track name, tempo, time signature); remaining message types remain pending.
-- Unknown meta events are preserved and unit tests verify this behavior.
+- `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), handles running status, normalizes Note On events with velocity 0 to Note Off, decodes SysEx events, and meta events (track name, tempo, time signature); remaining message types remain pending.
+- Unknown meta events and SysEx events are preserved and unit tests verify this behavior.
 - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -151,6 +151,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-21: Treat Note On with velocity 0 as Note Off in MidiFileParser and UMPParser.
 - 2025-08-22: Added Control Change decoding tests for MidiFileParser and UMPParser.
 - 2025-08-23: Added running status decoding test to MidiFileParser.
+- 2025-08-24: Added SysEx event decoding test to MidiFileParser.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -218,6 +218,22 @@ final class MidiFileParserTests: XCTestCase {
         }
     }
 
+    func testSysExEventDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x0A,
+            0x00, 0xF0, 0x03, 0x01, 0x02, 0x03,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let sysEx = events[0] as? SysExEvent {
+            XCTAssertEqual(sysEx.rawData, Data([0x01, 0x02, 0x03]))
+        } else {
+            XCTFail("Expected SysExEvent")
+        }
+    }
+
     func testUnknownMetaEventPreserved() throws {
         let bytes: [UInt8] = [
             0x4D, 0x54, 0x72, 0x6B,


### PR DESCRIPTION
## Summary
- test SysEx event parsing in `MidiFileParser`
- document new test in parser agent log and implementation plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68908e8c89d08325a773c64ae80ff6f2