### PR TITLE
Add SysEx8 decoding test for UMP parser

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -6,7 +6,7 @@
 - UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
-- Tests cover help/version output, unknown flags, and SMF header/track parsing (including running status, Control Change, Program Change, and Pitch Bend decoding). Csound and FluidSynth headers are vendored for consistent builds.
+- Tests cover help/version output, unknown flags, SMF header/track parsing (including running status, Control Change, Program Change, and Pitch Bend decoding), and UMP parsing for SysEx7/SysEx8, group/channel mapping, and error cases. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), handles running status, normalizes Note On events with velocity 0 to Note Off, decodes SysEx events, and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events and SysEx events are preserved and unit tests verify this behavior.
 - `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -152,6 +152,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-22: Added Control Change decoding tests for MidiFileParser and UMPParser.
 - 2025-08-23: Added running status decoding test to MidiFileParser.
 - 2025-08-24: Added SysEx event decoding test to MidiFileParser.
+- 2025-08-25: Added SysEx8 decoding test to UMPParser.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -156,6 +156,19 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.rawData, Data(bytes))
     }
 
+    func testSysEx8Decoding() throws {
+        let bytes: [UInt8] = [
+            0x60, 0x00, 0x12, 0x34,
+            0x56, 0x78, 0x9A, 0xBC,
+            0xDE, 0xF0, 0x00, 0x00
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? SysExEvent else {
+            return XCTFail("Expected SysExEvent")
+        }
+        XCTAssertEqual(event.rawData, Data(bytes))
+    }
+
     func testGroupChannelMapping() throws {
         // Group 2, channel 10 should map to unified channel 42
         let bytes: [UInt8] = [0x22, 0x9A, 0x3C, 0x40]


### PR DESCRIPTION
## Summary
- add unit test covering SysEx8 packet decoding in UMPParser
- document UMP parser test coverage in ImplementationPlan
- log SysEx8 test in Parsers agent plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890917b13c48325bafcdb61fd37d694