### PR TITLE
Handle MIDI2 velocity zero as Note Off

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -9,7 +9,7 @@
 - Tests cover help/version output, unknown flags, SMF header/track parsing (including running status, Control Change, Program Change, and Pitch Bend decoding), and UMP parsing for SysEx7/SysEx8, group/channel mapping, and error cases. Csound and FluidSynth headers are vendored for consistent builds.
 - `MidiFileParser` parses SMF header, track events, channel voice messages (Note On/Off, Control Change, Program Change, Pitch Bend, Channel Pressure, Polyphonic Key Pressure), handles running status, normalizes Note On events with velocity 0 to Note Off, decodes SysEx events, and meta events (track name, tempo, time signature); remaining message types remain pending.
 - Unknown meta events and SysEx events are preserved and unit tests verify this behavior.
-- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
+- `UMPParser` decodes utility, system real-time/common, SysEx7 and SysEx8, MIDI 1.0 and MIDI 2.0 channel voice messages (including Program Change, Pitch Bend, Channel Pressure, and Polyphonic Key Pressure) and normalizes Note On velocity 0 to Note Off for MIDI 1.0 and MIDI 2.0 packets, maps group/channel pairs into unified channel numbers, and validates misaligned or truncated packets; additional UMP message types remain pending.
 - Unified MIDI event model introduced; `MidiFileParser` and `UMPParser` emit protocol-based events.
 
 ## Action Plan

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -95,7 +95,8 @@ struct UMPParser {
             case 0x90:
                 let note = UInt8((data1 >> 8) & 0xFF)
                 let vel = ChannelVoiceEvent.normalizeVelocity(UInt16((data2 >> 16) & 0xFFFF))
-                return ChannelVoiceEvent(timestamp: 0, type: .noteOn, channelNumber: channel, noteNumber: note, velocity: vel, controllerValue: nil)
+                let eventType: MidiEventType = vel == 0 ? .noteOff : .noteOn
+                return ChannelVoiceEvent(timestamp: 0, type: eventType, channelNumber: channel, noteNumber: note, velocity: vel, controllerValue: nil)
             case 0xA0:
                 let note = UInt8((data1 >> 8) & 0xFF)
                 let pressure = ChannelVoiceEvent.normalizeController(data2)

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -153,6 +153,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-23: Added running status decoding test to MidiFileParser.
 - 2025-08-24: Added SysEx event decoding test to MidiFileParser.
 - 2025-08-25: Added SysEx8 decoding test to UMPParser.
+- 2025-08-26: Fixed MIDI 2.0 Note On velocity 0 handling in UMPParser and added corresponding test.
 
 ---
 

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -58,6 +58,20 @@ final class UMPParserTests: XCTestCase {
         XCTAssertEqual(event.velocity, 0x7F)
     }
 
+    func testMIDI2NoteOnZeroVelocityTreatedAsNoteOff() throws {
+        let bytes: [UInt8] = [
+            0x40, 0x90, 0x3C, 0x00,
+            0x00, 0x00, 0x00, 0x00
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.type, .noteOff)
+        XCTAssertEqual(event.noteNumber, 0x3C)
+        XCTAssertEqual(event.velocity, 0x00)
+    }
+
     func testMIDI2ProgramChangeDecoding() throws {
         let bytes: [UInt8] = [
             0x40, 0xC0, 0x00, 0x00,


### PR DESCRIPTION
## Summary
- interpret MIDI 2.0 Note On messages with velocity 0 as Note Off in `UMPParser`
- exercise zero-velocity MIDI 2.0 note handling in `UMPParserTests`
- document parser capability updates in ImplementationPlan and agent log

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689096ef852083259895e80b5e597f01