### PR TITLE
Add tempo and time signature MIDI meta event types

### DIFF
--- a/Sources/Parsers/MidiEvents.swift
+++ b/Sources/Parsers/MidiEvents.swift
@@ -67,6 +67,52 @@ struct MetaEvent: MidiEventProtocol {
     var rawData: Data? { data }
 }
 
+/// Represents tempo meta events.
+struct TempoEvent: MidiEventProtocol {
+    let timestamp: UInt32
+    /// Microseconds per quarter note.
+    let microsecondsPerQuarter: UInt32
+
+    var type: MidiEventType { .meta }
+    var channel: UInt8? { nil }
+    var noteNumber: UInt8? { nil }
+    var velocity: UInt8? { nil }
+    var controllerValue: UInt32? { nil }
+    var metaType: UInt8? { 0x51 }
+    var rawData: Data? {
+        let b1 = UInt8((microsecondsPerQuarter >> 16) & 0xFF)
+        let b2 = UInt8((microsecondsPerQuarter >> 8) & 0xFF)
+        let b3 = UInt8(microsecondsPerQuarter & 0xFF)
+        return Data([b1, b2, b3])
+    }
+}
+
+/// Represents time signature meta events.
+struct TimeSignatureEvent: MidiEventProtocol {
+    let timestamp: UInt32
+    let numerator: UInt8
+    /// Denominator expressed as the actual value (e.g. 4 for 4/4).
+    let denominator: UInt8
+    let metronome: UInt8
+    let thirtySeconds: UInt8
+
+    var type: MidiEventType { .meta }
+    var channel: UInt8? { nil }
+    var noteNumber: UInt8? { nil }
+    var velocity: UInt8? { nil }
+    var controllerValue: UInt32? { nil }
+    var metaType: UInt8? { 0x58 }
+    var rawData: Data? {
+        var exp: UInt8 = 0
+        var denom = denominator
+        while denom > 1 {
+            denom >>= 1
+            exp += 1
+        }
+        return Data([numerator, exp, metronome, thirtySeconds])
+    }
+}
+
 /// Represents key signature meta events.
 struct KeySignatureEvent: MidiEventProtocol {
     let timestamp: UInt32

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -117,7 +117,22 @@ struct MidiFileParser {
                     let metaSlice = data[index..<index + Int(length)]
                     defer { index += Int(length) }
 
-                    if metaType == 0x59 && length >= 2 {
+                    if metaType == 0x51 && length == 3 {
+                        var value: UInt32 = 0
+                        let start = metaSlice.startIndex
+                        value |= UInt32(metaSlice[start]) << 16
+                        value |= UInt32(metaSlice[start.advanced(by: 1)]) << 8
+                        value |= UInt32(metaSlice[start.advanced(by: 2)])
+                        events.append(TempoEvent(timestamp: currentTime, microsecondsPerQuarter: value))
+                    } else if metaType == 0x58 && length == 4 {
+                        let start = metaSlice.startIndex
+                        let numerator = metaSlice[start]
+                        let denomExp = metaSlice[start.advanced(by: 1)]
+                        let denominator = UInt8(1 << denomExp)
+                        let metronome = metaSlice[start.advanced(by: 2)]
+                        let thirtySeconds = metaSlice[start.advanced(by: 3)]
+                        events.append(TimeSignatureEvent(timestamp: currentTime, numerator: numerator, denominator: denominator, metronome: metronome, thirtySeconds: thirtySeconds))
+                    } else if metaType == 0x59 && length >= 2 {
                         let key = Int8(bitPattern: metaSlice[metaSlice.startIndex])
                         let isMinor = metaSlice[metaSlice.startIndex.advanced(by: 1)] == 1
                         events.append(KeySignatureEvent(timestamp: currentTime, key: key, isMinor: isMinor))

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -160,6 +160,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-08-30: Added system common/real-time message decoding and running status clearing to MidiFileParser with unit tests.
 - 2025-08-31: Added real-time message running status preservation test to MidiFileParser.
 - 2025-09-01: Added key signature meta event decoding to MidiFileParser and unit test.
+- 2025-09-02: Added TempoEvent and TimeSignatureEvent decoding to MidiFileParser and unit tests.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -45,29 +45,20 @@ final class MidiFileParserTests: XCTestCase {
         } else {
             XCTFail("Expected MetaEvent track name")
         }
-        if let meta = events[1] as? MetaEvent, let data = meta.rawData {
-            XCTAssertEqual(meta.timestamp, 0)
-            XCTAssertEqual(meta.metaType, 0x51)
-            let value = data.withUnsafeBytes { ptr -> UInt32 in
-                var tmp: UInt32 = 0
-                tmp |= UInt32(ptr[0]) << 16
-                tmp |= UInt32(ptr[1]) << 8
-                tmp |= UInt32(ptr[2])
-                return tmp
-            }
-            XCTAssertEqual(value, 500_000)
+        if let tempo = events[1] as? TempoEvent {
+            XCTAssertEqual(tempo.timestamp, 0)
+            XCTAssertEqual(tempo.microsecondsPerQuarter, 500_000)
         } else {
-            XCTFail("Expected MetaEvent tempo")
+            XCTFail("Expected TempoEvent")
         }
-        if let meta = events[2] as? MetaEvent, let data = meta.rawData {
-            XCTAssertEqual(meta.timestamp, 0)
-            XCTAssertEqual(meta.metaType, 0x58)
-            XCTAssertEqual(data[data.startIndex], 4)
-            XCTAssertEqual(data[data.startIndex.advanced(by: 1)], 2)
-            XCTAssertEqual(data[data.startIndex.advanced(by: 2)], 0x18)
-            XCTAssertEqual(data[data.startIndex.advanced(by: 3)], 0x08)
+        if let ts = events[2] as? TimeSignatureEvent {
+            XCTAssertEqual(ts.timestamp, 0)
+            XCTAssertEqual(ts.numerator, 4)
+            XCTAssertEqual(ts.denominator, 4)
+            XCTAssertEqual(ts.metronome, 0x18)
+            XCTAssertEqual(ts.thirtySeconds, 0x08)
         } else {
-            XCTFail("Expected MetaEvent time signature")
+            XCTFail("Expected TimeSignatureEvent")
         }
         if let noteOn = events[3] as? ChannelVoiceEvent {
             XCTAssertEqual(noteOn.timestamp, 0)


### PR DESCRIPTION
## Summary
- add `TempoEvent` and `TimeSignatureEvent` structs for MIDI meta events
- parse tempo and time signature meta events into the new types
- track addition in parser agent log and extend tests

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890ac1fd6cc83259e8a55e6ee447a93