### PR TITLE
Add SMPTE offset meta event parsing

### DIFF
--- a/Sources/Parsers/MidiEvents.swift
+++ b/Sources/Parsers/MidiEvents.swift
@@ -200,6 +200,24 @@ struct KeySignatureEvent: MidiEventProtocol {
     var rawData: Data? { Data([UInt8(bitPattern: key), isMinor ? 1 : 0]) }
 }
 
+/// Represents SMPTE offset meta events.
+struct SMPTEOffsetEvent: MidiEventProtocol {
+    let timestamp: UInt32
+    let hour: UInt8
+    let minute: UInt8
+    let second: UInt8
+    let frame: UInt8
+    let subframe: UInt8
+
+    var type: MidiEventType { .meta }
+    var channel: UInt8? { nil }
+    var noteNumber: UInt8? { nil }
+    var velocity: UInt8? { nil }
+    var controllerValue: UInt32? { nil }
+    var metaType: UInt8? { 0x54 }
+    var rawData: Data? { Data([hour, minute, second, frame, subframe]) }
+}
+
 /// Represents SysEx events.
 struct SysExEvent: MidiEventProtocol {
     let timestamp: UInt32

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -139,6 +139,14 @@ struct MidiFileParser {
                         value |= UInt32(metaSlice[start.advanced(by: 1)]) << 8
                         value |= UInt32(metaSlice[start.advanced(by: 2)])
                         events.append(TempoEvent(timestamp: currentTime, microsecondsPerQuarter: value))
+                    } else if metaType == 0x54 && length == 5 {
+                        let start = metaSlice.startIndex
+                        let hour = metaSlice[start]
+                        let minute = metaSlice[start.advanced(by: 1)]
+                        let second = metaSlice[start.advanced(by: 2)]
+                        let frame = metaSlice[start.advanced(by: 3)]
+                        let subframe = metaSlice[start.advanced(by: 4)]
+                        events.append(SMPTEOffsetEvent(timestamp: currentTime, hour: hour, minute: minute, second: second, frame: frame, subframe: subframe))
                     } else if metaType == 0x58 && length == 4 {
                         let start = metaSlice.startIndex
                         let numerator = metaSlice[start]

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -165,6 +165,7 @@ The CLI currently supports rendering from the following source formats:
 - 2025-09-04: Added LyricEvent decoding to MidiFileParser and unit test.
 - 2025-09-05: Added MarkerEvent decoding to MidiFileParser and unit test.
 - 2025-09-06: Added InstrumentNameEvent and CuePointEvent decoding to MidiFileParser with unit tests.
+- 2025-09-07: Added SMPTE offset meta event decoding to MidiFileParser and unit test.
 
 ---
 

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -384,6 +384,26 @@ final class MidiFileParserTests: XCTestCase {
         }
     }
 
+    func testSMPTEOffsetMetaEventDecoding() throws {
+        let bytes: [UInt8] = [
+            0x4D, 0x54, 0x72, 0x6B,
+            0x00, 0x00, 0x00, 0x0D,
+            0x00, 0xFF, 0x54, 0x05, 0x10, 0x20, 0x30, 0x40, 0x50,
+            0x00, 0xFF, 0x2F, 0x00
+        ]
+        let events = try MidiFileParser.parseTrack(data: Data(bytes))
+        XCTAssertEqual(events.count, 2)
+        if let smpte = events[0] as? SMPTEOffsetEvent {
+            XCTAssertEqual(smpte.hour, 0x10)
+            XCTAssertEqual(smpte.minute, 0x20)
+            XCTAssertEqual(smpte.second, 0x30)
+            XCTAssertEqual(smpte.frame, 0x40)
+            XCTAssertEqual(smpte.subframe, 0x50)
+        } else {
+            XCTFail("Expected SMPTEOffsetEvent")
+        }
+    }
+
     func testUnknownMetaEventPreserved() throws {
         let bytes: [UInt8] = [
             0x4D, 0x54, 0x72, 0x6B,


### PR DESCRIPTION
## Summary
- add SMPTEOffsetEvent type for SMPTE offset meta events
- parse SMPTE offset events in `MidiFileParser`
- cover SMPTE offset parsing with a dedicated unit test and log the change

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890bb7e1ee083259a08feb0bd97c8d2