### PR TITLE
Add basic Storyboard parser and CLI support

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -2,7 +2,7 @@
 
 ## Status Quo
 
-- CLI handles `.fountain`, `.ly`, and `.csd` inputs; `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` inputs remain unimplemented, though MIDI and UMP files are now detected by signature.
+- CLI handles `.fountain`, `.ly`, `.csd`, and `.storyboard` inputs; `.mid`/`.midi`, `.ump`, and `.session` inputs remain unimplemented, though MIDI and UMP files are now detected by signature.
 - UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
@@ -15,7 +15,7 @@
 
 ## Action Plan
 
-1. Implement parsers and renderers for `.storyboard`, `.mid`/`.midi`, `.ump`, and `.session` files (SMF header parser implemented).
+1. Implement parsers and renderers for `.mid`/`.midi`, `.ump`, and `.session` files (Storyboard parser implemented).
 2. ~~Add `ump` output target in the render dispatcher and ensure all formats are documented.~~
 3. ~~Apply environment variable fallback when width/height flags are absent and add tests for precedence.~~
 4. ~~Replace polling watch mode with `DispatchSource.makeFileSystemObjectSource` on platforms that support it.~~

--- a/Sources/CLI/RenderCLI.swift
+++ b/Sources/CLI/RenderCLI.swift
@@ -103,7 +103,8 @@ public struct RenderCLI: ParsableCommand {
             let text = String(decoding: fileData, as: UTF8.self)
             return CsoundScore(orchestra: "", score: text)
         case "storyboard":
-            throw ValidationError("Storyboard DSL parsing is not implemented")
+            let text = String(decoding: fileData, as: UTF8.self)
+            return StoryboardParser.parse(text)
         case "mid", "midi":
             throw ValidationError("Parsing for MIDI files is not implemented")
         case "ump":

--- a/Sources/Parsers/StoryboardParser.swift
+++ b/Sources/Parsers/StoryboardParser.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Parser for simple Storyboard DSL files.
+public struct StoryboardParser {
+    /// Parses a storyboard script into a `Storyboard` instance.
+    /// Format:
+    ///
+    /// Scene: Name
+    /// Text: content line
+    /// Transition: crossfade 1
+    ///
+    /// - Parameter text: The raw storyboard text.
+    /// - Returns: Constructed `Storyboard`.
+    public static func parse(_ text: String) -> Storyboard {
+        var steps: [StoryboardStep] = []
+        let lines = text.split(separator: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+        var index = 0
+        while index < lines.count {
+            let line = lines[index]
+            if line.lowercased().hasPrefix("scene:") {
+                let name = line.dropFirst("scene:".count).trimmingCharacters(in: .whitespaces)
+                index += 1
+                var content = ""
+                if index < lines.count, lines[index].lowercased().hasPrefix("text:") {
+                    content = lines[index].dropFirst("text:".count).trimmingCharacters(in: .whitespaces)
+                    index += 1
+                }
+                let scene = Scene(name) { Text(content) }
+                steps.append(.scene(scene))
+            } else if line.lowercased().hasPrefix("transition:") {
+                let rest = line.dropFirst("transition:".count).trimmingCharacters(in: .whitespaces)
+                let parts = rest.split(separator: " ")
+                let style: Transition.Style = parts.first?.lowercased() == "tween" ? .tween : .crossfade
+                let frames = parts.count > 1 ? Int(parts[1]) ?? 1 : 1
+                let transition = Transition(style: style, frames: frames)
+                steps.append(.transition(transition))
+                index += 1
+            } else {
+                index += 1
+            }
+        }
+        return Storyboard(steps: steps)
+    }
+}
+
+public extension Storyboard {
+    /// Convenience initializer for constructing a storyboard from steps.
+    init(steps: [StoryboardStep]) {
+        self.steps = steps
+    }
+}
+
+extension Storyboard: Renderable {
+    public func render() -> String {
+        CodexStoryboardPreviewer.prompt(self)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -1,6 +1,6 @@
 # 🧩 Teatro Parser Agent
 
-**Last Updated:** August 04, 2025  
+**Last Updated:** September 08, 2025
 **Maintainer:** FountainAI / Codex Agents  
 **Directory:** `Sources/Parsers/agent.md`  
 **Mission:** Close the gap between declared input format support and verified parser coverage in the Teatro CLI.
@@ -29,7 +29,7 @@ The Parser Agent is responsible for implementing and maintaining _native Swift 6
 | `.csd` (Csound)    | ⚠️ Partial  | ❌ raw load only | ✓ | ❌ |
 | `.mid` (SMF)       | ✅ Complete | ✓ `MidiFileParser` | ✓ | ✓ |
 | `.ump` (MIDI 2.0)  | ✅ Complete | ✓ `UMPParser` | ✓ | ✓ |
-| `.storyboard`      | ❌ Missing  | ❌ | ❌ | ❌ |
+| `.storyboard`      | ⚠️ Partial  | ✓ `StoryboardParser` | ✓ | ✓ |
 | `.session`         | ❌ Missing  | ❌ | ❌ | ❌ |
 
 ---
@@ -39,13 +39,14 @@ The Parser Agent is responsible for implementing and maintaining _native Swift 6
 ### 1. Parsers
 - [x] `MidiFileParser.swift` with full event decoding
 - [x] `UMPParser.swift` supporting UMP formats 1.0/2.0
-- [ ] `StoryboardParser.swift` (Storyboard DSL)
+- [x] `StoryboardParser.swift` (Storyboard DSL)
 - [ ] `SessionParser.swift` (Teatro container format)
 - [ ] Canonical event unification (`MidiEventProtocol`)
 
 ### 2. CLI Integration
 - [x] Dispatch by file extension
-- [ ] Add `.storyboard`, `.session` to dispatcher
+- [x] Add `.storyboard` to dispatcher
+- [ ] Add `.session` to dispatcher
 - [ ] `--force-format`, `--renderer`, `--dump-events` CLI flags
 - [ ] `--emit-ump` output mode
 
@@ -61,7 +62,7 @@ The Parser Agent is responsible for implementing and maintaining _native Swift 6
 ### 5. Testing
 - [x] `MidiFileParserTests.swift`
 - [x] `UMPParserTests.swift`
-- [ ] `Tests/StoryboardParserTests.swift`
+- [x] `Tests/StoryboardParserTests.swift`
 - [ ] `Tests/SessionParserTests.swift`
 - [ ] Fixture-based event normalization tests
 
@@ -195,6 +196,7 @@ The Parser Agent is responsible for implementing and maintaining _native Swift 6
 - 2025-09-05: Added MarkerEvent decoding to MidiFileParser and unit test.
 - 2025-09-06: Added InstrumentNameEvent and CuePointEvent decoding to MidiFileParser with unit tests.
 - 2025-09-07: Added SMPTE offset meta event decoding to MidiFileParser and unit test.
+- 2025-09-08: Added basic StoryboardParser with CLI integration and unit test.
 
 
 All implementations must be verifiable via `swift test` and conform to:
@@ -211,3 +213,6 @@ All implementations must be verifiable via `swift test` and conform to:
 - [ ] Sync with `ImplementationPlan.md`
 - [ ] Cross-check against Codex milestone table
 
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/StoryboardParserTests.swift
+++ b/Tests/StoryboardParserTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Teatro
+
+final class StoryboardParserTests: XCTestCase {
+    func testParsesScenesAndTransitions() {
+        let text = """
+        Scene: First
+        Text: A
+        Transition: crossfade 1
+        Scene: Second
+        Text: B
+        """
+        let storyboard = StoryboardParser.parse(text)
+        XCTAssertEqual(storyboard.steps.count, 3)
+        guard case .scene(let first) = storyboard.steps[0] else { return XCTFail("Expected scene") }
+        XCTAssertEqual(first.name, "First")
+        guard case .transition(let trans) = storyboard.steps[1] else { return XCTFail("Expected transition") }
+        XCTAssertEqual(trans.style, .crossfade)
+        XCTAssertEqual(trans.frames, 1)
+        guard case .scene(let second) = storyboard.steps[2] else { return XCTFail("Expected scene") }
+        XCTAssertEqual(second.name, "Second")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement a minimal Storyboard DSL parser and make Storyboard conform to `Renderable`
- wire `.storyboard` inputs through the CLI
- cover parsing of scenes and transitions with a unit test

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890c09b939c8325bc52c6684c623fe0