### PR TITLE
Add basic SessionParser and CLI support

### DIFF
--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -2,7 +2,7 @@
 
 ## Status Quo
 
-- CLI handles `.fountain`, `.ly`, `.csd`, and `.storyboard` inputs; `.mid`/`.midi`, `.ump`, and `.session` inputs remain unimplemented, though MIDI and UMP files are now detected by signature.
+- CLI handles `.fountain`, `.ly`, `.csd`, `.storyboard`, and `.session` inputs; `.mid`/`.midi` and `.ump` inputs remain unimplemented, though MIDI and UMP files are now detected by signature.
 - UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
@@ -15,7 +15,7 @@
 
 ## Action Plan
 
-1. Implement parsers and renderers for `.mid`/`.midi`, `.ump`, and `.session` files (Storyboard parser implemented).
+1. Implement parsers and renderers for `.mid`/`.midi` and `.ump` files (session parser implemented).
 2. ~~Add `ump` output target in the render dispatcher and ensure all formats are documented.~~
 3. ~~Apply environment variable fallback when width/height flags are absent and add tests for precedence.~~
 4. ~~Replace polling watch mode with `DispatchSource.makeFileSystemObjectSource` on platforms that support it.~~

--- a/Sources/CLI/RenderCLI.swift
+++ b/Sources/CLI/RenderCLI.swift
@@ -110,7 +110,8 @@ public struct RenderCLI: ParsableCommand {
         case "ump":
             throw ValidationError("Parsing for UMP files is not implemented")
         case "session":
-            throw ValidationError("Parsing for .session files is not implemented")
+            let text = String(decoding: fileData, as: UTF8.self)
+            return SessionParser.parse(text)
         default:
             if signature == Data([0x4d, 0x54, 0x68, 0x64]) { // "MThd"
                 throw ValidationError("Parsing for MIDI files is not implemented")

--- a/Sources/Parsers/SessionParser.swift
+++ b/Sources/Parsers/SessionParser.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Simple parser for `.session` files.
+/// Currently treats the session file as plain text and wraps it into a `Session` renderable.
+public struct SessionParser {
+    /// Parses the session text into a `Session`.
+    /// - Parameter text: Raw session text.
+    /// - Returns: A `Session` renderable wrapping the text.
+    public static func parse(_ text: String) -> Session {
+        Session(text: text)
+    }
+}
+
+/// Represents a session log or container for the CLI.
+public struct Session: Renderable {
+    /// Raw textual content of the session.
+    public let text: String
+
+    /// Creates a new session from raw text.
+    public init(text: String) {
+        self.text = text
+    }
+
+    /// Renders the session as plain text.
+    public func render() -> String {
+        text
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SessionParserTests.swift
+++ b/Tests/SessionParserTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Teatro
+
+final class SessionParserTests: XCTestCase {
+    func testParsesRawText() {
+        let text = "Line one\nLine two"
+        let session = SessionParser.parse(text)
+        XCTAssertEqual(session.text, text)
+        XCTAssertEqual(session.render(), text)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- Implement simple SessionParser treating `.session` files as plain text
- Dispatch `.session` inputs through SessionParser in RenderCLI
- Document session support in ImplementationPlan and add unit tests

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890c336c3688325b02e27281d90e8db