### PR TITLE
Add UMPParser event normalization tests

### DIFF
--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -1,6 +1,6 @@
 # 🧩 Teatro Parser Agent
 
-**Last Updated:** September 09, 2025
+**Last Updated:** September 10, 2025
 **Maintainer:** FountainAI / Codex Agents  
 **Directory:** `Sources/Parsers/agent.md`  
 **Mission:** Close the gap between declared input format support and verified parser coverage in the Teatro CLI.
@@ -64,7 +64,7 @@ The Parser Agent is responsible for implementing and maintaining _native Swift 6
 - [x] `UMPParserTests.swift`
 - [x] `Tests/StoryboardParserTests.swift`
 - [x] `Tests/SessionParserTests.swift`
-- [ ] Fixture-based event normalization tests
+- [x] Fixture-based event normalization tests
 
 ---
 
@@ -198,6 +198,7 @@ The Parser Agent is responsible for implementing and maintaining _native Swift 6
 - 2025-09-07: Added SMPTE offset meta event decoding to MidiFileParser and unit test.
 - 2025-09-08: Added basic StoryboardParser with CLI integration and unit test.
 - 2025-09-09: Added basic SessionParser with CLI dispatch and unit test.
+- 2025-09-10: Added event normalization tests for UMPParser verifying 16-bit velocity and 32-bit controller normalization.
 
 
 All implementations must be verifiable via `swift test` and conform to:

--- a/Tests/MIDITests/EventNormalizationTests.swift
+++ b/Tests/MIDITests/EventNormalizationTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import Teatro
+
+final class EventNormalizationTests: XCTestCase {
+    func testVelocityNormalization() throws {
+        let bytes: [UInt8] = [
+            0x40, 0x90, 0x3C, 0x00,
+            0xFF, 0xFF, 0x00, 0x00
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.velocity, 0xFF)
+    }
+
+    func testControllerNormalization() throws {
+        let bytes: [UInt8] = [
+            0x40, 0xB0, 0x07, 0x00,
+            0xFF, 0xFF, 0xFF, 0xFF
+        ]
+        let events = try UMPParser.parse(data: Data(bytes))
+        guard let event = events.first as? ChannelVoiceEvent else {
+            return XCTFail("Expected ChannelVoiceEvent")
+        }
+        XCTAssertEqual(event.controllerValue, UInt32(0xFF))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add tests verifying UMPParser normalizes 16-bit velocities and 32-bit controller values
- mark parser agent task complete and log the addition

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890c736efbc83258e6188c534898625