### PR TITLE
Add coverage doc and update parser matrix

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -1,0 +1,24 @@
+# Coverage Report
+
+This document tracks test coverage for the Teatro project. It is updated as the project evolves.
+
+## Generating Coverage
+
+Run the tests with coverage enabled:
+
+```bash
+swift test --enable-code-coverage
+```
+
+Then generate a human-readable report (example using llvm-cov):
+
+```bash
+llvm-cov show .build/debug/TeatroPackageTests.xctest/Contents/MacOS/TeatroPackageTests -instr-profile=.build/debug/codecov/default.profdata > Coverage.txt
+```
+
+## Current Summary
+
+Coverage metrics have not yet been collected. Integrate coverage generation into CI to populate this section.
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -28,7 +28,7 @@
 | Grammar docs           | `Docs/Chapters/StoryboardDSL.md`, `SessionFormat.md`                    | Write        | ⏳ TODO | Define syntax/spec          | docs, spec           |
 | Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⏳ TODO | Need fixture MIDI/session   | tests, fixtures      |
 | Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⏳ TODO | CLI outputs not verified    | tests, cli           |
-| Coverage tracking      | `COVERAGE.md`                                                           | Add          | ⏳ TODO | —                           | coverage, report     |
+| Coverage tracking      | `COVERAGE.md`                                                           | Add          | ⚠️ Partial | Needs coverage metrics      | coverage, report     |
 
 ---
 
@@ -49,3 +49,6 @@ Codex agents should consume this matrix **row-by-row or batch-by-tag** (e.g. `"p
   - `ImplementationPlan.md`
   - `RenderCLI.swift` support matrix
   - `Docs/Chapters/`
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document how to generate code coverage in a new `COVERAGE.md`
- update parser agent matrix to mark coverage tracking as partially complete and add copyright footer

## Testing
- `swift build`
- `swift test --skip-build`


------
https://chatgpt.com/codex/tasks/task_e_6890cc2953708325bc5c5a6981d6a4da