### PR TITLE
Add session parser fixture and update backlog

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,10 @@ let package = Package(
             name: "TeatroTests",
             dependencies: ["Teatro"],
             path: "Tests",
-            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests", "SamplerTests", "CLI"]
+            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests", "SamplerTests", "CLI"],
+            resources: [
+                .process("Fixtures")
+            ]
         ),
         .testTarget(
             name: "StoryboardDSLTests",

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -26,7 +26,7 @@
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | Implement    | ⏳ TODO | Playback integration        | audio, output        |
 | `MidiEventProtocol`    | `MidiEvents.swift`, shared model                                        | Refactor     | ⏳ TODO | Cross-parser normalization  | core, protocol       |
 | Grammar docs           | `Docs/Chapters/StoryboardDSL.md`, `SessionFormat.md`                    | Write        | ⏳ TODO | Define syntax/spec          | docs, spec           |
-| Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⏳ TODO | Need fixture MIDI/session   | tests, fixtures      |
+| Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⚠️ Partial | Need fixture MIDI           | tests, fixtures      |
 | Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⏳ TODO | CLI outputs not verified    | tests, cli           |
 | Coverage tracking      | `COVERAGE.md`                                                           | Add          | ⚠️ Partial | Needs coverage metrics      | coverage, report     |
 

--- a/Tests/Fixtures/sample.session
+++ b/Tests/Fixtures/sample.session
@@ -1,0 +1,4 @@
+Line one
+Line two
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SessionParserTests.swift
+++ b/Tests/SessionParserTests.swift
@@ -2,8 +2,9 @@ import XCTest
 @testable import Teatro
 
 final class SessionParserTests: XCTestCase {
-    func testParsesRawText() {
-        let text = "Line one\nLine two"
+    func testParsesRawText() throws {
+        let url = Bundle.module.url(forResource: "sample", withExtension: "session")!
+        let text = try String(contentsOf: url)
         let session = SessionParser.parse(text)
         XCTAssertEqual(session.text, text)
         XCTAssertEqual(session.render(), text)


### PR DESCRIPTION
## Summary
- add sample `.session` fixture for parser tests
- load session parser test data from bundled fixtures
- mark test fixture coverage as partial in parser task matrix

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890cdf11d3c832595bed385d53494b7