### PR TITLE
Add CLI tests for storyboard and session inputs

### DIFF
--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -18,7 +18,7 @@
 | `.ump` parser          | `UMPParser.swift`, tests                                                | ✅ Complete   | ✅ Done  | —                           | parser, tested       |
 | `.storyboard` parser   | `StoryboardParser.swift`, CLI, tests, DSL doc                           | Implement    | ⏳ TODO | DSL grammar missing         | parser, dsl, cli     |
 | `.session` support     | `SessionParser.swift`, CLI, test, doc                                   | Implement    | ⏳ TODO | Container spec undefined    | parser, container    |
-| CLI dispatch           | `RenderCLI.swift`                                                       | Extend       | ⏳ TODO | Needs `.storyboard`, `.session` cases | cli         |
+| CLI dispatch           | `RenderCLI.swift`, tests                                                | ✅ Complete   | ✅ Done  | —                          | cli, tested        |
 | CLI flags              | `RenderCLI.swift`                                                       | Add          | ⏳ TODO | `--force-format`, etc.      | cli, flags           |
 | Watch mode (macOS)     | CLI watcher                                                             | Add          | ⏳ TODO | Add `DispatchSource` impl   | cli, watcher         |
 | UMP encoder            | `UMPEncoder.swift`                                                      | Implement    | ⏳ TODO | None                        | encoder, ump         |

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -87,6 +87,27 @@ final class RenderCLITests: XCTestCase {
         let data = try Data(contentsOf: url)
         XCTAssertEqual(data.count, 8)
     }
+
+    func testStoryboardInputRenders() throws {
+        let text = """
+        Scene: One
+        Text: Hi
+        """
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test.storyboard")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cli = try RenderCLI.parse([url.path])
+        XCTAssertNoThrow(try cli.run())
+    }
+
+    func testSessionInputRenders() throws {
+        let text = "session log"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test.session")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cli = try RenderCLI.parse([url.path])
+        XCTAssertNoThrow(try cli.run())
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- expand `RenderCLITests` to exercise `.storyboard` and `.session` files
- mark CLI dispatch as complete in parser task matrix

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890d77d8db083259c5fead77ef96418