### PR TITLE
docs: add initial coverage metrics

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,7 +18,11 @@ llvm-cov show .build/debug/TeatroPackageTests.xctest/Contents/MacOS/TeatroPackag
 
 ## Current Summary
 
-Coverage metrics have not yet been collected. Integrate coverage generation into CI to populate this section.
+As of 2025-08-04 the test suite reports:
+
+- **Regions:** 47.24% (4204 total, 2218 missed)
+- **Functions:** 56.07% (2044 total, 898 missed)
+- **Lines:** 44.16% (12011 total, 6707 missed)
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -28,7 +28,7 @@
 | Grammar docs           | `Docs/Chapters/StoryboardDSL.md`, `SessionFormat.md`                    | Write        | ⏳ TODO | Define syntax/spec          | docs, spec           |
 | Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⚠️ Partial | Need fixture MIDI           | tests, fixtures      |
 | Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⏳ TODO | CLI outputs not verified    | tests, cli           |
-| Coverage tracking      | `COVERAGE.md`                                                           | Add          | ⚠️ Partial | Needs coverage metrics      | coverage, report     |
+| Coverage tracking      | `COVERAGE.md`                                                           | Add          | ✅ Done  | —                          | coverage, report     |
 
 ---
 


### PR DESCRIPTION
## Summary
- track project test coverage statistics
- mark coverage tracking task complete in parser task matrix

## Testing
- `swift test`
- `swift test --enable-code-coverage`


------
https://chatgpt.com/codex/tasks/task_e_6890d9c57cb88325acc12e4a489ba7ac