### PR TITLE
docs: add grammar sections

### DIFF
--- a/Docs/Chapters/10_StoryboardDSL.md
+++ b/Docs/Chapters/10_StoryboardDSL.md
@@ -48,6 +48,21 @@ timeline:
 let svg = SVGAnimator.renderAnimatedSVG(storyboard: storyboard)
 ```
 
+### Grammar
+
+The parser also supports a plain‑text storyboard format with the following grammar:
+
+```ebnf
+storyboard  = { step , "\n" } ;
+step        = scene | transition ;
+scene       = "Scene:" , name , [ "\n" , "Text:" , content ] ;
+transition  = "Transition:" , style , [ frames ] ;
+style       = "crossfade" | "tween" ;
+frames      = integer ;
+```
+
+Keywords are case‑insensitive and lines are trimmed of surrounding whitespace.
+
 ### Runtime Use
 
 `Storyboard.frames()` can now be played back with `TeatroPlayerView`. Provide a

--- a/Docs/Chapters/13_SessionFormat.md
+++ b/Docs/Chapters/13_SessionFormat.md
@@ -4,6 +4,18 @@ _Serialization for captured CLI interactions._
 
 A `.session` file records a sequence of terminal commands and their textual output.  The file is plain UTF-8 text with no additional markup or metadata.  Each line represents exactly what appeared in the terminal during a recording.  Empty lines are preserved to maintain the original spacing.
 
+### Grammar
+
+```ebnf
+session   = { line , "\n" } ;
+line      = command | output ;
+command   = "$" , " " , text ;
+output    = text ;
+text      = { character - "\n" } ;
+```
+
+Each line is interpreted literally; commands begin with a dollar sign and a space, while output lines may contain any text.
+
 ### Example
 ```
 $ teatro --format codex sample.storyboard

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -25,7 +25,7 @@
 | `.csd` renderer        | `CSDRenderer.swift`                                                     | ✅ Complete   | ✅ Done  | —                           | renderer, csound    |
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | Implement    | ⏳ TODO | Playback integration        | audio, output        |
 | `MidiEventProtocol`    | `MidiEvents.swift`, shared model                                        | Refactor     | ⏳ TODO | Cross-parser normalization  | core, protocol       |
-| Grammar docs           | `Docs/Chapters/StoryboardDSL.md`, `Docs/Chapters/13_SessionFormat.md`   | Write        | ⏳ TODO | Define syntax/spec          | docs, spec           |
+| Grammar docs           | `Docs/Chapters/10_StoryboardDSL.md`, `Docs/Chapters/13_SessionFormat.md` | ✅ Complete   | ✅ Done | —                         | docs, spec           |
 | Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⚠️ Partial | Need fixture MIDI           | tests, fixtures      |
 | Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⏳ TODO | CLI outputs not verified    | tests, cli           |
 | Coverage tracking      | `COVERAGE.md`                                                           | Add          | ✅ Done  | —                          | coverage, report     |


### PR DESCRIPTION
## Summary
- document plain-text storyboard syntax
- specify `.session` file grammar
- mark grammar docs task complete

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890e70244908325a2757a3c13c60647