### PR TITLE
Implement MIDI 2.0 UMP encoder

### DIFF
--- a/Docs/Chapters/07_MIDI20DSL.md
+++ b/Docs/Chapters/07_MIDI20DSL.md
@@ -68,9 +68,16 @@ Encodes each `MIDI2Note` into raw Universal MIDI Packet words for playback or fi
 
 ```swift
 public struct UMPEncoder {
-    public static func encode(_ note: MIDI2Note) -> [UInt32] {
-        // Placeholder encoding
-        [0]
+    public static func encode(_ note: MIDI2Note, group: UInt8 = 0) -> [UInt32] {
+        let messageType: UInt32 = 0x4 << 28
+        let groupBits = UInt32(group & 0xF) << 24
+        let status: UInt32 = 0x9 << 20
+        let channelBits = UInt32(note.channel & 0xF) << 16
+        let noteBits = UInt32(note.note & 0x7F) << 8
+        let word1 = messageType | groupBits | status | channelBits | noteBits
+        let velocity = UInt32(max(0, min(0xFFFF, Int((note.velocity * 65535.0).rounded()))))
+        let word2 = velocity << 16
+        return [word1, word2]
     }
 }
 ```

--- a/Docs/ImplementationPlan.md
+++ b/Docs/ImplementationPlan.md
@@ -4,7 +4,7 @@
 
 - CLI handles `.fountain`, `.ly`, `.csd`, `.storyboard`, and `.session` inputs; `.mid`/`.midi` and `.ump` inputs remain unimplemented, though MIDI and UMP files are now detected by signature.
 - `CSDParser` extracts `<Orchestra>` and `<Score>` sections from `.csd` files and `CSDRenderer` writes complete `.csd` documents.
-- UMP rendering target encodes a placeholder UMP packet; full integration with parsers is pending.
+- UMP rendering target encodes MIDI 2.0 Note On packets via `UMPEncoder`; full integration with parsers is pending.
 - Environment variables for width/height now apply even when flags are absent.
 - Watch mode uses `DispatchSource.makeFileSystemObjectSource` for file monitoring on supported platforms and falls back to polling on Linux.
 - Tests cover help/version output, unknown flags, SMF header/track parsing (including running status, Control Change, Program Change, Pitch Bend decoding, timestamp accumulation, meta events such as track/instrument name, lyrics, markers, cue points, and error handling for invalid headers, tracks, and events), and UMP parsing for SysEx7/SysEx8, group/channel mapping, and error cases. Csound and FluidSynth headers are vendored for consistent builds, and the `FluidSynthSampler` backend enables real-time SoundFont playback.

--- a/Sources/MIDI/MIDI2.swift
+++ b/Sources/MIDI/MIDI2.swift
@@ -20,13 +20,4 @@ public struct MIDI2Note: Sendable, Equatable {
     }
 }
 
-public struct UMPEncoder {
-    public static func encode(_ note: MIDI2Note) -> [UInt32] {
-        let status: UInt32 = 0x40 << 24 | UInt32(note.channel & 0xF) << 16
-        let pitch = UInt32(note.note & 0x7F) << 8
-        let velocity = UInt32(max(0, min(65535, Int(note.velocity * 65535))))
-        let word1 = status | pitch | (velocity >> 8)
-        let word2 = UInt32(velocity & 0xFF) << 24
-        return [word1, word2]
-    }
-}
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/MIDI/UMPEncoder.swift
+++ b/Sources/MIDI/UMPEncoder.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Encodes `MIDI2Note` values into Universal MIDI Packet words.
+public struct UMPEncoder {
+    /// Encodes a single note as a 64-bit MIDI 2.0 Note On packet.
+    /// - Parameters:
+    ///   - note: The note to encode. Velocity is scaled to 16-bit resolution.
+    ///   - group: Optional UMP group number (0-15). Defaults to 0.
+    /// - Returns: An array of two 32-bit words representing the packet.
+    public static func encode(_ note: MIDI2Note, group: UInt8 = 0) -> [UInt32] {
+        let messageType: UInt32 = 0x4 << 28 // MIDI 2.0 Channel Voice Message
+        let groupBits = UInt32(group & 0xF) << 24
+        let status: UInt32 = 0x9 << 20 // Note On opcode
+        let channelBits = UInt32(note.channel & 0xF) << 16
+        let noteBits = UInt32(note.note & 0x7F) << 8
+        let word1 = messageType | groupBits | status | channelBits | noteBits
+
+        let velocity = UInt32(max(0, min(0xFFFF, Int((note.velocity * 65535.0).rounded()))))
+        let word2 = velocity << 16 // Attribute data unused
+        return [word1, word2]
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -21,7 +21,7 @@
 | CLI dispatch           | `RenderCLI.swift`, tests                                                | ✅ Complete   | ✅ Done  | —                          | cli, tested        |
 | CLI flags              | `RenderCLI.swift`                                                       | Add          | ⏳ TODO | `--force-format`, etc.      | cli, flags           |
 | Watch mode (macOS)     | CLI watcher                                                             | Add          | ⏳ TODO | Add `DispatchSource` impl   | cli, watcher         |
-| UMP encoder            | `UMPEncoder.swift`                                                      | Implement    | ⏳ TODO | None                        | encoder, ump         |
+| UMP encoder            | `UMPEncoder.swift`                                                      | ✅ Complete   | ✅ Done  | —                          | encoder, ump         |
 | `.csd` renderer        | `CSDRenderer.swift`                                                     | ✅ Complete   | ✅ Done  | —                           | renderer, csound    |
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | ✅ Complete   | ✅ Done  | —                          | audio, output        |
 | `MidiEventProtocol`    | `MidiEvents.swift`, shared model                                        | Refactor     | ⏳ TODO | Cross-parser normalization  | core, protocol       |

--- a/Tests/MIDITests/MIDI2Tests.swift
+++ b/Tests/MIDITests/MIDI2Tests.swift
@@ -5,7 +5,7 @@ final class MIDI2Tests: XCTestCase {
     func testUMPEncoderProducesWords() {
         let note = MIDI2Note(channel: 0, note: 60, velocity: 0.5, duration: 0.1)
         let packets = UMPEncoder.encode(note)
-        XCTAssertEqual(packets.count, 2)
+        XCTAssertEqual(packets, [0x40903C00, 0x80000000])
     }
 
     func testCSDRendererWritesFile() throws {


### PR DESCRIPTION
## Summary
- add UMPEncoder for generating MIDI 2.0 Note On packets
- document MIDI 2.0 encoder in the MIDI DSL guide
- mark UMP encoder task complete in parser backlog

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6890eb8eadf48325a0e4907af7ac0f82