### PR TITLE
docs: sync CLI docs with implementation

### DIFF
--- a/Docs/Chapters/03_RenderingBackends.md
+++ b/Docs/Chapters/03_RenderingBackends.md
@@ -138,10 +138,8 @@ Example output snippet:
 Run via the CLI:
 
 ```bash
-swift run RenderCLI svg-animated
+swift run RenderCLI --input demo.storyboard --format svgAnimated --output anim.svg
 ```
----
 
-`````text
-©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-`````
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Docs/Chapters/04_CLIIntegration.md
+++ b/Docs/Chapters/04_CLIIntegration.md
@@ -3,6 +3,8 @@ _Command-line tools for scripted rendering._
 
 The Teatro view engine exposes an ArgumentParser-powered command-line interface (`RenderCLI`) capable of rendering any `Renderable` to multiple backends.
 
+The executable entry point lives in [`Sources/CLI/main.swift`](../../Sources/CLI/main.swift) and invokes `RenderCLI.main()`. Output generators are defined by the `RenderTarget` enumeration in [`Sources/CLI/RenderCLI.swift`](../../Sources/CLI/RenderCLI.swift).
+
 ### Flags
 
 - `--input <file>` or positional file argument
@@ -16,7 +18,7 @@ The Teatro view engine exposes an ArgumentParser-powered command-line interface 
 
 - Omitting `--format` selects `codex` when writing to stdout and `png` when writing to a file.
 - When `--output` is absent, defaults such as `output.png`, `output.svg`, or `output.csd` are used.
-- Size flags take precedence over environment variables `TEATRO_SVG_WIDTH`, `TEATRO_SVG_HEIGHT`, `TEATRO_IMAGE_WIDTH`, and `TEATRO_IMAGE_HEIGHT`.
+- If `--width`/`--height` are omitted, the CLI reads `TEATRO_WIDTH` and `TEATRO_HEIGHT` and propagates them to `TEATRO_SVG_WIDTH`, `TEATRO_SVG_HEIGHT`, `TEATRO_IMAGE_WIDTH`, and `TEATRO_IMAGE_HEIGHT`.
 
 ### Examples
 

--- a/Docs/SystemArchitecture.md
+++ b/Docs/SystemArchitecture.md
@@ -30,6 +30,8 @@ _A high-level view of Teatro's modules and design patterns._
 
 **CLI Utilities** (`Sources/CLI`)
 - [`RenderCLI`](../Sources/CLI/RenderCLI.swift) exposes rendering targets via command line.
+- Entry point [`main.swift`](../Sources/CLI/main.swift) invokes `RenderCLI.main()`.
+- Generation targets are declared by the `RenderTarget` enum in [`RenderCLI.swift`](../Sources/CLI/RenderCLI.swift).
 
 ![AI Image Prompt: Diagram showing flow from Storyboard to SVGAnimator to final animated SVG output](storyboard-flow.png)
 
@@ -45,4 +47,4 @@ The modular structure allows adding new renderers or sampler backends with minim
 ![AI Image Prompt: Layered architecture showing ViewCore at the center, surrounded by Renderers, Audio, CLI and Tests](layered-architecture.png)
 
 ---
-``© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.``
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document CLI entry point and render target enumeration
- clarify environment variable fallbacks for width and height
- update rendering backend CLI example

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68910212afa08325813e924fdc090cef