### PR TITLE
Refactor MIDI event model for group-aware parsing

### DIFF
--- a/Sources/Parsers/MidiEvents.swift
+++ b/Sources/Parsers/MidiEvents.swift
@@ -18,6 +18,8 @@ enum MidiEventType {
 protocol MidiEventProtocol {
     var timestamp: UInt32 { get }
     var type: MidiEventType { get }
+    /// MIDI 2.0 group number if present.
+    var group: UInt8? { get }
     var channel: UInt8? { get }
     var noteNumber: UInt8? { get }
     var velocity: UInt8? { get }
@@ -29,6 +31,7 @@ protocol MidiEventProtocol {
 }
 
 extension MidiEventProtocol {
+    var group: UInt8? { nil }
     static func normalizeVelocity(_ value: UInt16) -> UInt8 {
         return UInt8(truncatingIfNeeded: value >> 8)
     }
@@ -42,12 +45,11 @@ extension MidiEventProtocol {
 struct ChannelVoiceEvent: MidiEventProtocol {
     let timestamp: UInt32
     let type: MidiEventType
-    let channelNumber: UInt8
+    let group: UInt8?
+    let channel: UInt8?
     let noteNumber: UInt8?
     let velocity: UInt8?
     let controllerValue: UInt32?
-
-    var channel: UInt8? { channelNumber }
     var metaType: UInt8? { nil }
     var rawData: Data? { nil }
 }
@@ -222,6 +224,7 @@ struct SMPTEOffsetEvent: MidiEventProtocol {
 struct SysExEvent: MidiEventProtocol {
     let timestamp: UInt32
     let data: Data
+    let group: UInt8?
 
     var type: MidiEventType { .sysEx }
     var channel: UInt8? { nil }
@@ -236,6 +239,7 @@ struct SysExEvent: MidiEventProtocol {
 struct UnknownEvent: MidiEventProtocol {
     let timestamp: UInt32
     let data: Data
+    let group: UInt8?
 
     var type: MidiEventType { .unknown }
     var channel: UInt8? { nil }

--- a/Sources/Parsers/MidiFileParser.swift
+++ b/Sources/Parsers/MidiFileParser.swift
@@ -69,43 +69,43 @@ struct MidiFileParser {
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
                 let note = data[index]
                 let velocity = data[index + 1]
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .noteOff, channelNumber: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .noteOff, group: nil, channel: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
                 index += 2
             case 0x90: // Note On (velocity 0 treated as Note Off)
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
                 let note = data[index]
                 let velocity = data[index + 1]
                 let eventType: MidiEventType = velocity == 0 ? .noteOff : .noteOn
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: eventType, channelNumber: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: eventType, group: nil, channel: channel, noteNumber: note, velocity: velocity, controllerValue: nil))
                 index += 2
             case 0xB0: // Control Change
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
                 let controller = data[index]
                 let value = data[index + 1]
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .controlChange, channelNumber: channel, noteNumber: controller, velocity: nil, controllerValue: UInt32(value)))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .controlChange, group: nil, channel: channel, noteNumber: controller, velocity: nil, controllerValue: UInt32(value)))
                 index += 2
             case 0xC0: // Program Change
                 guard index < end else { throw MidiFileParserError.invalidEvent }
                 let program = data[index]
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .programChange, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(program)))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .programChange, group: nil, channel: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(program)))
                 index += 1
             case 0xE0: // Pitch Bend
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
                 let lsb = UInt16(data[index])
                 let msb = UInt16(data[index + 1])
                 let value = (msb << 7) | lsb
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .pitchBend, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(value)))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .pitchBend, group: nil, channel: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(value)))
                 index += 2
             case 0xA0: // Polyphonic Key Pressure
                 guard index + 1 < end else { throw MidiFileParserError.invalidEvent }
                 let note = data[index]
                 let pressure = data[index + 1]
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: note, velocity: pressure, controllerValue: nil))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .polyphonicKeyPressure, group: nil, channel: channel, noteNumber: note, velocity: pressure, controllerValue: nil))
                 index += 2
             case 0xD0: // Channel Pressure
                 guard index < end else { throw MidiFileParserError.invalidEvent }
                 let pressure = data[index]
-                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(pressure)))
+                events.append(ChannelVoiceEvent(timestamp: currentTime, type: .channelPressure, group: nil, channel: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(pressure)))
                 index += 1
             case 0xF0:
                 if status == 0xFF { // Meta event
@@ -168,7 +168,7 @@ struct MidiFileParser {
                     let length = try readVariableLengthQuantity(data, index: &index)
                     guard index + Int(length) <= end else { throw MidiFileParserError.invalidEvent }
                     let sysExData = data[index..<index + Int(length)]
-                    events.append(SysExEvent(timestamp: currentTime, data: Data(sysExData)))
+                    events.append(SysExEvent(timestamp: currentTime, data: Data(sysExData), group: nil))
                     index += Int(length)
                 } else {
                     let length: Int
@@ -187,7 +187,7 @@ struct MidiFileParser {
                     for i in 0..<length {
                         raw.append(data[index + i])
                     }
-                    events.append(UnknownEvent(timestamp: currentTime, data: Data(raw)))
+                    events.append(UnknownEvent(timestamp: currentTime, data: Data(raw), group: nil))
                     index += length
                 }
             default:

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -58,67 +58,67 @@ struct UMPParser {
         case 0x2: // MIDI 1.0 Channel Voice Messages
             let word = words[0]
             let status = UInt8(((word >> 20) & 0x0F) << 4)
-            let channel = UInt8((group << 4) | UInt8((word >> 16) & 0x0F))
+            let channel = UInt8((word >> 16) & 0x0F)
             let data1 = UInt8((word >> 8) & 0x7F)
             let data2 = UInt8(word & 0x7F)
             switch status {
             case 0x80:
-                return ChannelVoiceEvent(timestamp: 0, type: .noteOff, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
+                return ChannelVoiceEvent(timestamp: 0, type: .noteOff, group: group, channel: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0x90:
                 let eventType: MidiEventType = data2 == 0 ? .noteOff : .noteOn
-                return ChannelVoiceEvent(timestamp: 0, type: eventType, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
+                return ChannelVoiceEvent(timestamp: 0, type: eventType, group: group, channel: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0xA0:
-                return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
+                return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, group: group, channel: channel, noteNumber: data1, velocity: data2, controllerValue: nil)
             case 0xB0:
-                return ChannelVoiceEvent(timestamp: 0, type: .controlChange, channelNumber: channel, noteNumber: data1, velocity: nil, controllerValue: UInt32(data2))
+                return ChannelVoiceEvent(timestamp: 0, type: .controlChange, group: group, channel: channel, noteNumber: data1, velocity: nil, controllerValue: UInt32(data2))
             case 0xC0:
-                return ChannelVoiceEvent(timestamp: 0, type: .programChange, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(data1))
+                return ChannelVoiceEvent(timestamp: 0, type: .programChange, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(data1))
             case 0xE0:
                 let value = UInt32((UInt16(data2) << 7) | UInt16(data1))
-                return ChannelVoiceEvent(timestamp: 0, type: .pitchBend, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: value)
+                return ChannelVoiceEvent(timestamp: 0, type: .pitchBend, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: value)
             case 0xD0:
-                return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(data1))
+                return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(data1))
             default:
-                return UnknownEvent(timestamp: 0, data: rawData(from: words))
+                return UnknownEvent(timestamp: 0, data: rawData(from: words), group: group)
             }
         case 0x4: // MIDI 2.0 Channel Voice Messages
             let word1 = words[0]
             let status = UInt8(((word1 >> 20) & 0x0F) << 4)
-            let channel = UInt8((group << 4) | UInt8((word1 >> 16) & 0x0F))
+            let channel = UInt8((word1 >> 16) & 0x0F)
             let data1 = UInt16(word1 & 0xFFFF)
             let data2 = words.count > 1 ? words[1] : 0
             switch status {
             case 0x80:
                 let note = UInt8((data1 >> 8) & 0xFF)
                 let vel = ChannelVoiceEvent.normalizeVelocity(UInt16((data2 >> 16) & 0xFFFF))
-                return ChannelVoiceEvent(timestamp: 0, type: .noteOff, channelNumber: channel, noteNumber: note, velocity: vel, controllerValue: nil)
+                return ChannelVoiceEvent(timestamp: 0, type: .noteOff, group: group, channel: channel, noteNumber: note, velocity: vel, controllerValue: nil)
             case 0x90:
                 let note = UInt8((data1 >> 8) & 0xFF)
                 let vel = ChannelVoiceEvent.normalizeVelocity(UInt16((data2 >> 16) & 0xFFFF))
                 let eventType: MidiEventType = vel == 0 ? .noteOff : .noteOn
-                return ChannelVoiceEvent(timestamp: 0, type: eventType, channelNumber: channel, noteNumber: note, velocity: vel, controllerValue: nil)
+                return ChannelVoiceEvent(timestamp: 0, type: eventType, group: group, channel: channel, noteNumber: note, velocity: vel, controllerValue: nil)
             case 0xA0:
                 let note = UInt8((data1 >> 8) & 0xFF)
                 let pressure = ChannelVoiceEvent.normalizeController(data2)
-                return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, channelNumber: channel, noteNumber: note, velocity: pressure, controllerValue: nil)
+                return ChannelVoiceEvent(timestamp: 0, type: .polyphonicKeyPressure, group: group, channel: channel, noteNumber: note, velocity: pressure, controllerValue: nil)
             case 0xB0:
                 let controller = UInt8((data1 >> 8) & 0xFF)
                 let value = ChannelVoiceEvent.normalizeController(data2)
-                return ChannelVoiceEvent(timestamp: 0, type: .controlChange, channelNumber: channel, noteNumber: controller, velocity: nil, controllerValue: UInt32(value))
+                return ChannelVoiceEvent(timestamp: 0, type: .controlChange, group: group, channel: channel, noteNumber: controller, velocity: nil, controllerValue: UInt32(value))
             case 0xC0:
                 let program = UInt8((data2 >> 24) & 0x7F)
-                return ChannelVoiceEvent(timestamp: 0, type: .programChange, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(program))
+                return ChannelVoiceEvent(timestamp: 0, type: .programChange, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: UInt32(program))
             case 0xD0:
-                return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
+                return ChannelVoiceEvent(timestamp: 0, type: .channelPressure, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
             case 0xE0:
-                return ChannelVoiceEvent(timestamp: 0, type: .pitchBend, channelNumber: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
+                return ChannelVoiceEvent(timestamp: 0, type: .pitchBend, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
             default:
-                return UnknownEvent(timestamp: 0, data: rawData(from: words))
+                return UnknownEvent(timestamp: 0, data: rawData(from: words), group: group)
             }
         case 0x5, 0x6: // SysEx7 and SysEx8
-            return SysExEvent(timestamp: 0, data: rawData(from: words))
+            return SysExEvent(timestamp: 0, data: rawData(from: words), group: group)
         default:
-            return UnknownEvent(timestamp: 0, data: rawData(from: words))
+            return UnknownEvent(timestamp: 0, data: rawData(from: words), group: group)
         }
     }
 

--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -24,7 +24,7 @@
 | UMP encoder            | `UMPEncoder.swift`                                                      | ✅ Complete   | ✅ Done  | —                          | encoder, ump         |
 | `.csd` renderer        | `CSDRenderer.swift`                                                     | ✅ Complete   | ✅ Done  | —                           | renderer, csound    |
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | ✅ Complete   | ✅ Done  | —                          | audio, output        |
-| `MidiEventProtocol`    | `MidiEvents.swift`, shared model                                        | Refactor     | ⏳ TODO | Cross-parser normalization  | core, protocol       |
+| `MidiEventProtocol`    | `MidiEvents.swift`, shared model                                        | ✅ Complete   | ✅ Done  | —                          | core, protocol       |
 | Grammar docs           | `Docs/Chapters/10_StoryboardDSL.md`, `Docs/Chapters/13_SessionFormat.md` | ✅ Complete   | ✅ Done | —                         | docs, spec           |
 | Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⚠️ Partial | Need fixture MIDI           | tests, fixtures      |
 | Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⏳ TODO | CLI outputs not verified    | tests, cli           |

--- a/Tests/MIDITests/UMPParserTests.swift
+++ b/Tests/MIDITests/UMPParserTests.swift
@@ -184,13 +184,14 @@ final class UMPParserTests: XCTestCase {
     }
 
     func testGroupChannelMapping() throws {
-        // Group 2, channel 10 should map to unified channel 42
+        // Group 2, channel 10 should remain separate
         let bytes: [UInt8] = [0x22, 0x9A, 0x3C, 0x40]
         let events = try UMPParser.parse(data: Data(bytes))
         guard let event = events.first as? ChannelVoiceEvent else {
             return XCTFail("Expected ChannelVoiceEvent")
         }
-        XCTAssertEqual(event.channel, 0x2A)
+        XCTAssertEqual(event.group, 0x2)
+        XCTAssertEqual(event.channel, 0xA)
     }
 
     func testUnknownPacketPreserved() throws {

--- a/Tests/MidiFileParserTests.swift
+++ b/Tests/MidiFileParserTests.swift
@@ -64,6 +64,7 @@ final class MidiFileParserTests: XCTestCase {
             XCTAssertEqual(noteOn.channel, 0)
             XCTAssertEqual(noteOn.noteNumber, 0x3C)
             XCTAssertEqual(noteOn.velocity, 0x40)
+            XCTAssertNil(noteOn.group)
         } else {
             XCTFail("Expected ChannelVoiceEvent noteOn")
         }
@@ -72,6 +73,7 @@ final class MidiFileParserTests: XCTestCase {
             XCTAssertEqual(noteOff.channel, 0)
             XCTAssertEqual(noteOff.noteNumber, 0x3C)
             XCTAssertEqual(noteOff.velocity, 0x40)
+            XCTAssertNil(noteOff.group)
         } else {
             XCTFail("Expected ChannelVoiceEvent noteOff")
         }

--- a/Tests/UMPParserTests.swift
+++ b/Tests/UMPParserTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import XCTest
+@testable import Teatro
+
+final class UMPParserTests: XCTestCase {
+    func testChannelVoiceEventGroupAndChannel() throws {
+        let bytes: [UInt8] = [0x22, 0x93, 0x3C, 0x40]
+        let events = try UMPParser.parse(data: Data(bytes))
+        XCTAssertEqual(events.count, 1)
+        if let event = events.first as? ChannelVoiceEvent {
+            XCTAssertEqual(event.group, 0x2)
+            XCTAssertEqual(event.channel, 0x3)
+            XCTAssertEqual(event.noteNumber, 0x3C)
+            XCTAssertEqual(event.velocity, 0x40)
+        } else {
+            XCTFail("Expected ChannelVoiceEvent")
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+


### PR DESCRIPTION
## Summary
- add optional MIDI group identifier to `MidiEventProtocol` and channel voice events
- normalize UMP parsing by separating group and channel fields and updating SMF parsing accordingly
- cover group/channel handling with new and updated tests

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6891043180ac83258efcfda451fca20d