### PR TITLE
feat: refine cli flags and watcher

### DIFF
--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -19,8 +19,8 @@
 | `.storyboard` parser   | `StoryboardParser.swift`, CLI, tests, DSL doc                           | ✅ Complete   | ✅ Done  | —                          | parser, dsl, cli     |
 | `.session` support     | `SessionParser.swift`, CLI, tests, `Docs/Chapters/13_SessionFormat.md`  | ✅ Complete   | ✅ Done  | —                          | parser, container    |
 | CLI dispatch           | `RenderCLI.swift`, tests                                                | ✅ Complete   | ✅ Done  | —                          | cli, tested        |
-| CLI flags              | `RenderCLI.swift`                                                       | Add          | ⚠️ Partial | `--force-format` added, more flags pending | cli, flags           |
-| Watch mode (macOS)     | CLI watcher                                                             | Add          | ⏳ TODO | Add `DispatchSource` impl   | cli, watcher         |
+| CLI flags              | `RenderCLI.swift`                                                       | Add          | ⚠️ Partial | `--force-format` added, env precedence in place, more flags pending | cli, flags           |
+| Watch mode (macOS)     | CLI watcher                                                             | Add          | ⚠️ Partial | DispatchSource + polling; tests pending   | cli, watcher         |
 | UMP encoder            | `UMPEncoder.swift`                                                      | ✅ Complete   | ✅ Done  | —                          | encoder, ump         |
 | `.csd` renderer        | `CSDRenderer.swift`                                                     | ✅ Complete   | ✅ Done  | —                           | renderer, csound    |
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | ✅ Complete   | ✅ Done  | —                          | audio, output        |

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -35,11 +35,9 @@ final class RenderCLITests: XCTestCase {
     }
 
     func testEnvironmentFallback() throws {
-        setenv("TEATRO_WIDTH", "800", 1)
-        setenv("TEATRO_HEIGHT", "600", 1)
+        setenv("TEATRO_SVG_WIDTH", "800", 1)
+        setenv("TEATRO_SVG_HEIGHT", "600", 1)
         defer {
-            unsetenv("TEATRO_WIDTH")
-            unsetenv("TEATRO_HEIGHT")
             unsetenv("TEATRO_SVG_WIDTH")
             unsetenv("TEATRO_IMAGE_WIDTH")
             unsetenv("TEATRO_SVG_HEIGHT")


### PR DESCRIPTION
## Summary
- honor TEATRO_* dimension environment variables when width/height flags are absent
- watch mode now listens for write/delete/rename events
- document CLI progress in parser task matrix and update tests

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6891081c87a08325b8db20d36ae41305