### PR TITLE
Add macOS watch mode test

### DIFF
--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -20,7 +20,8 @@
 | `.session` support     | `SessionParser.swift`, CLI, tests, `Docs/Chapters/13_SessionFormat.md`  | ✅ Complete   | ✅ Done  | —                          | parser, container    |
 | CLI dispatch           | `RenderCLI.swift`, tests                                                | ✅ Complete   | ✅ Done  | —                          | cli, tested        |
 | CLI flags              | `RenderCLI.swift`                                                       | Add          | ⚠️ Partial | `--force-format` added, env precedence in place, more flags pending | cli, flags           |
-| Watch mode (macOS)     | CLI watcher                                                             | Add          | ⚠️ Partial | DispatchSource + polling; tests pending   | cli, watcher         |
+| Watch mode (macOS)     | CLI watcher                                                             | ✅ Complete   | ✅ Done  |
+—                          | cli, watcher         |
 | UMP encoder            | `UMPEncoder.swift`                                                      | ✅ Complete   | ✅ Done  | —                          | encoder, ump         |
 | `.csd` renderer        | `CSDRenderer.swift`                                                     | ✅ Complete   | ✅ Done  | —                           | renderer, csound    |
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | ✅ Complete   | ✅ Done  | —                          | audio, output        |


### PR DESCRIPTION
## Summary
- make CLI watch mode testable and schedule timer polling on non-Darwin
- add macOS watch mode unit test
- mark watch mode task complete in parser agent matrix

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6891888395788325bb17a6dfc20b910b