### PR TITLE
Fix PNG fallback file naming

### DIFF
--- a/Sources/Renderers/ImageRenderer.swift
+++ b/Sources/Renderers/ImageRenderer.swift
@@ -38,9 +38,17 @@ public struct ImageRenderer {
         cairo_surface_destroy(surface)
 #else
         // Fallback when Cairo is unavailable: generate an SVG next to the desired PNG path.
-        let svgPath = path.replacingOccurrences(of: ".png", with: ".svg")
+        let requestedURL = URL(fileURLWithPath: path)
+        let svgURL: URL
+        if requestedURL.pathExtension.lowercased() == "png" {
+            svgURL = requestedURL.deletingPathExtension().appendingPathExtension("svg")
+        } else {
+            svgURL = requestedURL
+        }
         let svg = SVGRenderer.render(view)
-        try? svg.write(toFile: svgPath, atomically: true, encoding: .utf8)
+        try? svg.write(toFile: svgURL.path, atomically: true, encoding: .utf8)
 #endif
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/RendererFileTests/RendererFileTests.swift
+++ b/Tests/RendererFileTests/RendererFileTests.swift
@@ -8,7 +8,7 @@ final class RendererFileTests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("svg")
         try svg.write(to: url, atomically: true, encoding: .utf8)
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
-        let content = try String(contentsOf: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
         XCTAssertTrue(content.contains("<svg"))
     }
 
@@ -20,10 +20,12 @@ final class RendererFileTests: XCTestCase {
             let data = try Data(contentsOf: url)
             XCTAssertFalse(data.isEmpty)
         } else {
-            let alt = URL(fileURLWithPath: url.path.replacingOccurrences(of: ".png", with: ".svg"))
+            let alt = url.deletingPathExtension().appendingPathExtension("svg")
             XCTAssertTrue(FileManager.default.fileExists(atPath: alt.path))
-            let content = try String(contentsOf: alt)
+            let content = try String(contentsOf: alt, encoding: .utf8)
             XCTAssertTrue(content.contains("<svg"))
         }
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- ensure PNG fallback uses URL path logic and respects original file extension
- adjust RendererFileTests to match new fallback behavior and silence warnings

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6891a1ccb8308333893c428224d5cb69