### PR TITLE
Add MIDI fixture and CLI parity test

### DIFF
--- a/Sources/Parsers/agent.md
+++ b/Sources/Parsers/agent.md
@@ -27,8 +27,8 @@
 | FluidSynth backend     | `TeatroSampler.swift`                                                   | ✅ Complete   | ✅ Done  | —                          | audio, output        |
 | `MidiEventProtocol`    | `MidiEvents.swift`, shared model                                        | ✅ Complete   | ✅ Done  | —                          | core, protocol       |
 | Grammar docs           | `Docs/Chapters/10_StoryboardDSL.md`, `Docs/Chapters/13_SessionFormat.md` | ✅ Complete   | ✅ Done | —                         | docs, spec           |
-| Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ⚠️ Partial | Need fixture MIDI           | tests, fixtures      |
-| Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⏳ TODO | CLI outputs not verified    | tests, cli           |
+| Test fixture coverage  | `Tests/Fixtures/`, normalization tests                                  | Add          | ✅ Done  | —                           | tests, fixtures      |
+| Test parity tracker    | `Tests/Parsers/*.swift`, CLI tests                                      | Expand       | ⚠️ Partial | Further CLI output checks needed | tests, cli           |
 | Coverage tracking      | `COVERAGE.md`                                                           | Add          | ✅ Done  | —                          | coverage, report     |
 
 ---

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -83,6 +83,22 @@ final class RenderCLITests: XCTestCase {
         }
     }
 
+    func testMidiFixtureFileThrows() throws {
+        let fixtures = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Fixtures")
+        let base64 = try String(contentsOf: fixtures.appendingPathComponent("sample.mid")).components(separatedBy: "\n").first ?? ""
+        let data = Data(base64Encoded: base64)!
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("fixture.mid")
+        try data.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cli = try RenderCLI.parse([url.path])
+        XCTAssertThrowsError(try cli.run()) { error in
+            guard let val = error as? ValidationError, val.description.contains("MIDI") else {
+                XCTFail("Expected MIDI parsing error")
+                return
+            }
+        }
+    }
+
     func testUMPSignatureRecognition() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("umptest.bin")
         defer { try? FileManager.default.removeItem(at: url) }

--- a/Tests/Fixtures/sample.mid
+++ b/Tests/Fixtures/sample.mid
@@ -1,0 +1,2 @@
+TVRoZAAAAAYAAAABAGBNVHJrAAAABAD/LwA=
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add base64-encoded MIDI test fixture
- extend CLI tests to confirm `.mid` input produces MIDI-specific error
- update parser agent matrix to reflect new fixture and partial CLI test coverage

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6892e76e47f483338d07c5c9eaa333e8