### PR TITLE
Silence warnings in sampler, parser, and CLI tests

### DIFF
--- a/Sources/Audio/Samplers/CsoundSampler.swift
+++ b/Sources/Audio/Samplers/CsoundSampler.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CCsound
 
-extension OpaquePointer: @unchecked Sendable {}
+extension OpaquePointer: @retroactive @unchecked Sendable {}
 
 /// Csound-based sampler using libcsound for realtime playback.
 public actor CsoundSampler: SampleSource {
@@ -21,7 +21,7 @@ public actor CsoundSampler: SampleSource {
 
     /// Loads a Csound orchestra file and prepares the engine.
     public func loadInstrument(_ path: String) async throws {
-        try await stopAll()
+        await stopAll()
         let orc = try String(contentsOfFile: path)
         let cs = csoundCreate(nil)
         csoundSetOption(cs, "-d")             // no displays

--- a/Sources/ViewCore/FountainParser.swift
+++ b/Sources/ViewCore/FountainParser.swift
@@ -208,7 +208,7 @@ public final class FountainParser {
     }
 
     private func parseBody(line: String, previousBlank: Bool, nextBlank: Bool, lastElement: FountainElementType?) -> FountainElementType? {
-        var trimmed = line.trimmingCharacters(in: .whitespaces)
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty { return nil }
 
         // FountainAI overrides
@@ -402,3 +402,5 @@ public final class FountainParser {
         return result
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -45,7 +45,7 @@ final class RenderCLITests: XCTestCase {
     }
 
     func testUnknownFlag() {
-        XCTAssertExit { try RenderCLI.parse(["--unknown"]) }
+        XCTAssertExit { _ = try RenderCLI.parse(["--unknown"]) }
     }
 
     func testEnvironmentFallback() throws {


### PR DESCRIPTION
## Summary
- quiet the sendable extension by marking `OpaquePointer` retroactively and remove redundant try from the Csound sampler
- tighten Fountain parser by using an immutable `trimmed` and add missing copyright footer
- discard the result of RenderCLI parsing in the unknown flag test to silence a warning

## Testing
- `swift build`
- `swift test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68933d2689fc8333ba6722c58e6bb5c3