### PR TITLE
Add tests for animation, parsers, and view core

### DIFF
--- a/Tests/AnimatorTests.swift
+++ b/Tests/AnimatorTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Teatro
+
+final class AnimatorTests: XCTestCase {
+    func testRenderFramesCreatesFiles() async {
+        struct Dummy: Renderable {
+            func render() -> String { "Hello" }
+        }
+        let base = "test_frame"
+        let fileManager = FileManager.default
+        let check: (Int) -> String = { index in
+            let png = "Animations/\(base)_\(index).png"
+            if fileManager.fileExists(atPath: png) { return png }
+            return "Animations/\(base)_\(index).svg"
+        }
+        for i in 0..<2 {
+            let path = check(i)
+            if fileManager.fileExists(atPath: path) {
+                try? fileManager.removeItem(atPath: path)
+            }
+        }
+
+        await Animator.renderFrames([Dummy(), Dummy()], baseName: base)
+
+        for i in 0..<2 {
+            let path = check(i)
+            XCTAssertTrue(fileManager.fileExists(atPath: path))
+            try? fileManager.removeItem(atPath: path)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/CSDParserTests.swift
+++ b/Tests/CSDParserTests.swift
@@ -17,6 +17,34 @@ final class CSDParserTests: XCTestCase {
         XCTAssertEqual(score.orchestra.trimmingCharacters(in: .whitespacesAndNewlines), "f 1 0 0 10 1")
         XCTAssertEqual(score.score.trimmingCharacters(in: .whitespacesAndNewlines), "i1 0 1 0.5")
     }
+
+    func testMissingSectionsThrow() {
+        let csdMissingOrchestra = """
+        <CsoundSynthesizer>
+        <Score>i1 0 1 0.5</Score>
+        </CsoundSynthesizer>
+        """
+        XCTAssertThrowsError(try CSDParser.parse(csdMissingOrchestra)) { error in
+            XCTAssertEqual(error as? CSDParserError, .missingOrchestra)
+        }
+        let csdMissingScore = """
+        <CsoundSynthesizer>
+        <Orchestra>f 1 0 0 10 1</Orchestra>
+        </CsoundSynthesizer>
+        """
+        XCTAssertThrowsError(try CSDParser.parse(csdMissingScore)) { error in
+            XCTAssertEqual(error as? CSDParserError, .missingScore)
+        }
+        let csdUnclosedOrchestra = """
+        <CsoundSynthesizer>
+        <Orchestra>f 1 0 0 10 1
+        <Score>i1 0 1 0.5</Score>
+        </CsoundSynthesizer>
+        """
+        XCTAssertThrowsError(try CSDParser.parse(csdUnclosedOrchestra)) { error in
+            XCTAssertEqual(error as? CSDParserError, .missingOrchestra)
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DispatcherPromptTests.swift
+++ b/Tests/DispatcherPromptTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Teatro
+
+final class DispatcherPromptTests: XCTestCase {
+    func testInitAndRender() {
+        let prompt = DispatcherPrompt()
+        let output = prompt.render()
+        XCTAssertTrue(output.contains("Dispatcher"))
+        XCTAssertTrue(output.contains("<content>"))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainElementTests.swift
+++ b/Tests/FountainElementTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Teatro
+
+final class FountainElementTests: XCTestCase {
+    func testRenderVariants() {
+        XCTAssertEqual(FountainElement.sceneHeading("INT. HOUSE").render(), "# INT. HOUSE")
+        XCTAssertEqual(FountainElement.characterCue("John").render(), "\nJOHN")
+        XCTAssertEqual(FountainElement.dialogue("Hello").render(), "\tHello")
+        XCTAssertEqual(FountainElement.action("Act").render(), "Act")
+        XCTAssertEqual(FountainElement.transition("CUT TO").render(), "CUT TO >>")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainParserTests.swift
+++ b/Tests/FountainParserTests.swift
@@ -152,5 +152,39 @@ EXT. CITY STREET - NIGHT
         XCTAssertTrue(nodes.contains { $0.type == .promote })
         XCTAssertTrue(nodes.contains { $0.type == .summary })
     }
+    func testLyricsLine() {
+        let script = "~la la"
+        let nodes = FountainParser().parse(script)
+        XCTAssertTrue(nodes.contains { $0.type == .lyrics })
+    }
+
+    func testCharacterWithCaretMixedCase() {
+        let script = "\nJoe^"
+        let nodes = FountainParser().parse(script)
+        XCTAssertTrue(nodes.contains { $0.type == .action && $0.rawText == "Joe^" })
+    }
+
+    func testParentheticalContext() {
+        let script = """
+JOHN
+(whispers)
+INT. HOUSE - DAY
+(parenthetical?)
+"""
+        let nodes = FountainParser().parse(script)
+        XCTAssertEqual(nodes[1].type, .parenthetical)
+        XCTAssertTrue(nodes.contains { $0.type == .action && $0.rawText == "(parenthetical?)" })
+    }
+
+    func testInlineEscapesAndBoldItalic() {
+        let script = "JOHN\nThis \\*isn't\\* ***very*** complex\\"
+        let nodes = FountainParser().parse(script)
+        let dialogue = nodes.first { $0.type == .dialogue }
+        XCTAssertNotNil(dialogue)
+        let children = dialogue!.children
+        XCTAssertTrue(children.contains { if case .emphasis(style: .boldItalic) = $0.type { return true } else { return false } })
+        XCTAssertFalse(children.contains { if case .emphasis(style: .italic) = $0.type { return true } else { return false } })
+    }
 }
 
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/LilyScoreTests.swift
+++ b/Tests/LilyScoreTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Teatro
+
+final class LilyScoreTests: XCTestCase {
+    func testRenderToPDFWritesSource() {
+        let score = LilyScore("c'4")
+        let filename = "testScore"
+        let lyPath = "/tmp/\(filename).ly"
+        try? FileManager.default.removeItem(atPath: lyPath)
+        score.renderToPDF(filename: filename)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lyPath))
+        try? FileManager.default.removeItem(atPath: lyPath)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/MIDITests/MidiEventPropertyTests.swift
+++ b/Tests/MIDITests/MidiEventPropertyTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Teatro
+
+final class MidiEventPropertyTests: XCTestCase {
+    func testDefaultGroupIsNil() {
+        let event = MetaEvent(timestamp: 0, meta: 0x01, data: Data())
+        XCTAssertNil(event.group)
+    }
+
+    func testChannelVoiceEventMetaAndRawDataNil() {
+        let event = ChannelVoiceEvent(timestamp: 0, type: .noteOn, group: nil, channel: 1, noteNumber: 60, velocity: 100, controllerValue: nil)
+        XCTAssertNil(event.metaType)
+        XCTAssertNil(event.rawData)
+    }
+
+    func testMetaEventPropertiesNil() {
+        let event = MetaEvent(timestamp: 0, meta: 0x01, data: Data())
+        XCTAssertNil(event.noteNumber)
+        XCTAssertNil(event.velocity)
+        XCTAssertNil(event.controllerValue)
+    }
+
+    func testTempoEventProperties() {
+        let event = TempoEvent(timestamp: 0, microsecondsPerQuarter: 500000)
+        XCTAssertEqual(event.type, .meta)
+        XCTAssertNil(event.channel)
+        XCTAssertNil(event.noteNumber)
+        XCTAssertNil(event.velocity)
+        XCTAssertNil(event.controllerValue)
+        XCTAssertEqual(event.metaType, 0x51)
+        XCTAssertEqual(event.rawData, Data([0x07, 0xA1, 0x20]))
+    }
+
+    func testTimeSignatureEventProperties() {
+        let event = TimeSignatureEvent(timestamp: 0, numerator: 4, denominator: 4, metronome: 24, thirtySeconds: 8)
+        XCTAssertEqual(event.type, .meta)
+        XCTAssertNil(event.channel)
+        XCTAssertNil(event.noteNumber)
+        XCTAssertNil(event.velocity)
+        XCTAssertNil(event.controllerValue)
+        XCTAssertEqual(event.metaType, 0x58)
+        XCTAssertEqual(event.rawData, Data([4, 2, 24, 8]))
+    }
+
+    func testTrackNameEventProperties() {
+        let event = TrackNameEvent(timestamp: 0, name: "Track")
+        XCTAssertEqual(event.type, .meta)
+        XCTAssertNil(event.channel)
+        XCTAssertNil(event.noteNumber)
+        XCTAssertNil(event.velocity)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add animator frame rendering test ensuring PNG/SVG output
- expand CSD parser tests and cover MIDI event properties
- verify DispatcherPrompt and Fountain element rendering, plus LilyScore and Fountain parser behaviors

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68934b721bec83338e3d0c1c1002bd5d