### PR TITLE
Add audio and renderer tests

### DIFF
--- a/Sources/Renderers/ImageRenderer.swift
+++ b/Sources/Renderers/ImageRenderer.swift
@@ -6,12 +6,12 @@ import Foundation
 
 public struct ImageRenderer {
     // Default image width in points. Override with `TEATRO_IMAGE_WIDTH`.
-    private static var width: Int {
+    static var width: Int {
         Int(ProcessInfo.processInfo.environment["TEATRO_IMAGE_WIDTH"] ?? "800") ?? 800
     }
 
     // Default image height in points. Override with `TEATRO_IMAGE_HEIGHT`.
-    private static var height: Int {
+    static var height: Int {
         Int(ProcessInfo.processInfo.environment["TEATRO_IMAGE_HEIGHT"] ?? "600") ?? 600
     }
 

--- a/Tests/RendererFileTests/RendererFileTests.swift
+++ b/Tests/RendererFileTests/RendererFileTests.swift
@@ -26,6 +26,15 @@ final class RendererFileTests: XCTestCase {
             XCTAssertTrue(content.contains("<svg"))
         }
     }
+
+    func testImageRendererFallbackWithoutPNGExtension() throws {
+        let view = Text("Plain")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        ImageRenderer.renderToPNG(view, to: url.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let content = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(content.contains("<svg"))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/RendererTests.swift
+++ b/Tests/RendererTests.swift
@@ -61,4 +61,15 @@ final class RendererTests: XCTestCase {
         XCTAssertTrue(svg.contains("begin=\"0s\""), "First scene should begin at 0s")
         XCTAssertTrue(svg.contains("begin=\"1s\""), "Fade out or second scene should begin at 1s")
     }
+
+    func testImageRendererDimensionEnvironmentOverrides() {
+        setenv("TEATRO_IMAGE_WIDTH", "1024", 1)
+        setenv("TEATRO_IMAGE_HEIGHT", "768", 1)
+        XCTAssertEqual(ImageRenderer.width, 1024)
+        XCTAssertEqual(ImageRenderer.height, 768)
+        unsetenv("TEATRO_IMAGE_WIDTH")
+        unsetenv("TEATRO_IMAGE_HEIGHT")
+    }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SamplerTests/CompatibilityBridgeTests.swift
+++ b/Tests/SamplerTests/CompatibilityBridgeTests.swift
@@ -22,4 +22,27 @@ final class CompatibilityBridgeTests: XCTestCase {
         let content = lily.render()
         XCTAssertTrue(content.contains("c'4"))
     }
+
+    func testLilyScoreDynamics() {
+        let cases: [(Float, String)] = [
+            (0.95, "\\ff"),
+            (0.75, "\\f"),
+            (0.55, "\\mf"),
+            (0.35, "\\p"),
+            (0.1, "\\pp")
+        ]
+        for (vel, dyn) in cases {
+            let event = MIDI2NoteEvent(channel: 0, note: 60, velocity: vel, pitch: 60, timbre: .zero, articulation: "none", timestamp: 0)
+            let content = MIDICompatibilityBridge.toLilyScore(event).render()
+            XCTAssertTrue(content.contains(dyn))
+        }
+    }
+
+    func testLilyScoreLowerOctave() {
+        let event = MIDI2NoteEvent(channel: 0, note: 24, velocity: 0.5, pitch: 24, timbre: .zero, articulation: "none", timestamp: 0)
+        let content = MIDICompatibilityBridge.toLilyScore(event).render()
+        XCTAssertTrue(content.contains("c,,4"))
+    }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SamplerTests/CsoundSamplerTests.swift
+++ b/Tests/SamplerTests/CsoundSamplerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Teatro
+
+final class CsoundSamplerTests: XCTestCase {
+    func testCsoundSamplerLifecycle() async throws {
+        let path = FileManager.default.currentDirectoryPath + "/assets/sine.orc"
+        weak var weakSampler: CsoundSampler?
+        do {
+            let sampler = CsoundSampler()
+            weakSampler = sampler
+            try await sampler.loadInstrument(path)
+            await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 1.0, duration: 0.1))
+            await sampler.stopAll()
+        }
+        await Task.yield()
+        XCTAssertNil(weakSampler)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SamplerTests/FluidSynthSamplerTests.swift
+++ b/Tests/SamplerTests/FluidSynthSamplerTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Teatro
+
+final class FluidSynthSamplerTests: XCTestCase {
+    func testFluidSynthSamplerLifecycle() async throws {
+        let path = FileManager.default.currentDirectoryPath + "/assets/example.sf2"
+        weak var weakSampler: FluidSynthSampler?
+        do {
+            let sampler = FluidSynthSampler()
+            weakSampler = sampler
+            try await sampler.loadInstrument(path)
+            await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 0.8, duration: 0.001))
+            try? await Task.sleep(nanoseconds: 5_000_000)
+            await sampler.stopAll()
+        }
+        await Task.yield()
+        XCTAssertNil(weakSampler)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- expose `ImageRenderer` dimensions for testing
- add tests for image renderer dimensions and fallback behavior
- cover Csound/FluidSynth sampler lifecycles and Lily score dynamics

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68934fd7bf048333b6b90bece2d88b15