### PR TITLE
Add audio sampler tests

### DIFF
--- a/Tests/SamplerTests/CsoundSamplerTests.swift
+++ b/Tests/SamplerTests/CsoundSamplerTests.swift
@@ -9,11 +9,20 @@ final class CsoundSamplerTests: XCTestCase {
             let sampler = CsoundSampler()
             weakSampler = sampler
             try await sampler.loadInstrument(path)
+            // Allow the background performance loop to spin at least once
+            try? await Task.sleep(nanoseconds: 1_000_000)
             await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 1.0, duration: 0.1))
             await sampler.stopAll()
         }
         await Task.yield()
         XCTAssertNil(weakSampler)
+    }
+
+    func testTriggerWithoutLoadDoesNothing() async {
+        let sampler = CsoundSampler()
+        // Should simply return as no instrument is loaded
+        await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 1.0, duration: 0.1))
+        await sampler.stopAll()
     }
 }
 

--- a/Tests/SamplerTests/FluidSynthSamplerTests.swift
+++ b/Tests/SamplerTests/FluidSynthSamplerTests.swift
@@ -16,6 +16,13 @@ final class FluidSynthSamplerTests: XCTestCase {
         await Task.yield()
         XCTAssertNil(weakSampler)
     }
+
+    func testTriggerWithoutLoadDoesNothing() async {
+        let sampler = FluidSynthSampler()
+        await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 0.5, duration: 0.0))
+        await sampler.stopAll()
+    }
+
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SamplerTests/TeatroSamplerTests.swift
+++ b/Tests/SamplerTests/TeatroSamplerTests.swift
@@ -4,10 +4,16 @@ import XCTest
 final class TeatroSamplerTests: XCTestCase {
     actor MockSource: SampleSource {
         private var triggered: [MIDI2Note] = []
+        private var loaded: [String] = []
+        private var stopped = false
+
         func trigger(_ note: MIDI2Note) async { triggered.append(note) }
-        func stopAll() async { triggered.removeAll() }
-        func loadInstrument(_ path: String) async throws {}
+        func stopAll() async { stopped = true }
+        func loadInstrument(_ path: String) async throws { loaded.append(path) }
+
         func notes() async -> [MIDI2Note] { triggered }
+        func loadedPaths() async -> [String] { loaded }
+        func didStop() async -> Bool { stopped }
     }
 
     func testTriggerDelegates() async throws {
@@ -17,5 +23,21 @@ final class TeatroSamplerTests: XCTestCase {
         await sampler.trigger(note)
         let triggered = await mock.notes()
         XCTAssertEqual(triggered.first, note)
+    }
+
+    func testLoadInstrumentDelegates() async throws {
+        let mock = MockSource()
+        let sampler = TeatroSampler(implementation: mock)
+        try await sampler.loadInstrument("instrument.path")
+        let paths = await mock.loadedPaths()
+        XCTAssertEqual(paths.first, "instrument.path")
+    }
+
+    func testStopAllDelegates() async {
+        let mock = MockSource()
+        let sampler = TeatroSampler(implementation: mock)
+        await sampler.stopAll()
+        let stopped = await mock.didStop()
+        XCTAssertTrue(stopped)
     }
 }


### PR DESCRIPTION
## Summary
- expand Csound sampler tests to exercise background loop and guard behavior
- cover FluidSynth sampler's no-load trigger case
- validate TeatroSampler delegation for trigger, loadInstrument, and stopAll

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68935f031e68833387282b1e44c80c45