### PR TITLE
test: expand ViewCore coverage

### DIFF
--- a/Tests/FountainParserTests.swift
+++ b/Tests/FountainParserTests.swift
@@ -185,6 +185,40 @@ INT. HOUSE - DAY
         XCTAssertTrue(children.contains { if case .emphasis(style: .boldItalic) = $0.type { return true } else { return false } })
         XCTAssertFalse(children.contains { if case .emphasis(style: .italic) = $0.type { return true } else { return false } })
     }
+
+    func testInlineFlushAppendsRemainingText() {
+        let script = "JOHN\nSay *something* now"
+        let nodes = FountainParser().parse(script)
+        let dialogue = nodes.first { $0.type == .dialogue }
+        XCTAssertNotNil(dialogue)
+        XCTAssertEqual(dialogue!.children.last?.rawText, " now")
+    }
+
+    func testTransitionRequiresAllCaps() {
+        let script = "Cut To:\n\n"
+        let nodes = FountainParser().parse(script)
+        XCTAssertEqual(nodes.first?.type, .action)
+    }
+
+    func testTransitionWithTrailingSpaceIsAction() {
+        let script = "\nCUT TO: \n\n"
+        let nodes = FountainParser().parse(script)
+        XCTAssertEqual(nodes.first?.type, .character)
+    }
+
+    func testSynopsisDisabledTreatsLineAsAction() {
+        let rules = RuleSet(enableSynopses: false)
+        let parser = FountainParser(rules: rules)
+        let nodes = parser.parse("= Summary")
+        XCTAssertEqual(nodes.first?.type, .action)
+    }
+
+    func testSectionDisabledTreatsLineAsAction() {
+        let rules = RuleSet(enableSections: false)
+        let parser = FountainParser(rules: rules)
+        let nodes = parser.parse("# Heading")
+        XCTAssertEqual(nodes.first?.type, .action)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FountainViewTests.swift
+++ b/Tests/FountainViewTests.swift
@@ -18,4 +18,19 @@ EXT. CITY - DAY
         XCTAssertTrue(lines.contains { $0.contains("ROBOT") })
         XCTAssertTrue(lines.contains { $0.contains("Hello.") })
     }
+
+    func testParentheticalMapsToDialogue() {
+        let script = """
+JOHN
+(whispers)
+Hello
+"""
+        let elements = FountainRenderer.parse(script)
+        XCTAssertEqual(elements.count, 3)
+        if case .dialogue(let txt) = elements[1] {
+            XCTAssertEqual(txt, "(whispers)")
+        } else {
+            XCTFail("Expected parenthetical to map to dialogue")
+        }
+    }
 }

--- a/Tests/ViewCoreTests.swift
+++ b/Tests/ViewCoreTests.swift
@@ -37,4 +37,9 @@ final class ViewCoreTests: XCTestCase {
         XCTAssertEqual(Rule().render(), String(repeating: "-", count: 10))
         XCTAssertEqual(InputCursor().render(), "|")
     }
+
+    func testUnderlineAndPlainStyles() {
+        XCTAssertEqual(Text("U", style: .underline).render(), "_U_")
+        XCTAssertEqual(Text("P", style: .plain).render(), "P")
+    }
 }


### PR DESCRIPTION
## Summary
- ensure FountainRenderer handles parenthetical lines as dialogue
- verify FountainParser transition rules, inline flush, synopsis/section toggles
- cover underline and plain cases for TextStyle

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68936a88193c83338c3db4ece2851d0f