### PR TITLE
Fix CLI executable lookup and resource paths in tests

### DIFF
--- a/Sources/Animation/Animator.swift
+++ b/Sources/Animation/Animator.swift
@@ -3,8 +3,10 @@ import Foundation
 @MainActor
 public struct Animator {
     public static func renderFrames(_ frames: [Renderable], baseName: String = "frame") {
+        let directory = "Animations"
+        try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
         for (i, frame) in frames.enumerated() {
-            let path = "Animations/\(baseName)_\(i).png"
+            let path = "\(directory)/\(baseName)_\(i).png"
             ImageRenderer.renderToPNG(frame, to: path)
         }
     }

--- a/Tests/CLI/RenderCLICoverageTests.swift
+++ b/Tests/CLI/RenderCLICoverageTests.swift
@@ -265,19 +265,9 @@ final class RenderCLICoverageTests: XCTestCase {
     #endif
 
     func testRenderCLIMainExecutable() throws {
-        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let build = root.appendingPathComponent(".build")
-        let fm = FileManager.default
-        guard let enumerator = fm.enumerator(at: build, includingPropertiesForKeys: nil) else {
-            XCTFail("No build directory")
-            return
-        }
-        var exe: URL?
-        for case let url as URL in enumerator {
-            if url.lastPathComponent == "RenderCLI" { exe = url; break }
-        }
-        guard let exec = exe else {
-            XCTFail("Executable not found")
+        let exec = productsDirectory.appendingPathComponent("RenderCLI")
+        guard FileManager.default.fileExists(atPath: exec.path) else {
+            XCTFail("Executable not found at \(exec.path)")
             return
         }
         let process = Process()
@@ -291,6 +281,17 @@ final class RenderCLICoverageTests: XCTestCase {
         let output = String(decoding: data, as: UTF8.self)
         XCTAssertTrue(output.contains("0.1.0"))
     }
+}
+
+private var productsDirectory: URL {
+#if os(macOS)
+    for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+        return bundle.bundleURL.deletingLastPathComponent()
+    }
+    fatalError("Could not locate products directory")
+#else
+    return Bundle.main.bundleURL
+#endif
 }
 
 struct DummySysExEvent: MidiEventProtocol {

--- a/Tests/SamplerTests/CsoundSamplerTests.swift
+++ b/Tests/SamplerTests/CsoundSamplerTests.swift
@@ -3,7 +3,15 @@ import XCTest
 
 final class CsoundSamplerTests: XCTestCase {
     func testCsoundSamplerLifecycle() async throws {
-        let path = FileManager.default.currentDirectoryPath + "/assets/sine.orc"
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // CsoundSamplerTests.swift
+            .deletingLastPathComponent() // SamplerTests
+            .deletingLastPathComponent() // Tests
+        let path = root.appendingPathComponent("assets/sine.orc").path
+        guard FileManager.default.fileExists(atPath: path) else {
+            XCTFail("Missing resource at \(path)")
+            return
+        }
         weak var weakSampler: CsoundSampler?
         do {
             let sampler = CsoundSampler()


### PR DESCRIPTION
## Summary
- Ensure Animator creates its output directory before rendering frames
- Use static products directory to locate RenderCLI executable in tests
- Resolve sampler tests' path to sine.orc via file location

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_6893723d159083339e24b8de6ab31eff