### PR TITLE
docs: add coverage task matrix

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -2,41 +2,28 @@
 
 | Feature | File(s) or Area | Action | Status | Blockers | Tags |
 |---|---|---|---|---|---|
-| loadInstrument | Sources/Audio/Samplers/CsoundSampler.swift | Add tests to cover line(s) 33 of `loadInstrument` | ❌ |  | Audio |
-| trigger | Sources/Audio/Samplers/CsoundSampler.swift | Add tests to cover line(s) 39 of `trigger` | ❌ |  | Audio |
-| (global) | Sources/Audio/Samplers/FluidSynthSampler.swift | Add tests to cover line(s) 13,14,15 of `(global)` | ❌ |  | Audio |
-| loadInstrument | Sources/Audio/Samplers/FluidSynthSampler.swift | Add tests to cover line(s) 23,27,29 of `loadInstrument` | ❌ |  | Audio |
-| noteOff | Sources/Audio/Samplers/FluidSynthSampler.swift | Add tests to cover line(s) 54 of `noteOff` | ❌ |  | Audio |
-| trigger | Sources/Audio/Samplers/FluidSynthSampler.swift | Add tests to cover line(s) 43 of `trigger` | ❌ |  | Audio |
-| loadInstrument | Sources/Audio/TeatroSampler.swift | Add tests to cover line(s) 21,22,23,25,27,29,31,48 of `loadInstrument` | ❌ |  | Audio |
-| stopAll | Sources/Audio/TeatroSampler.swift | Add tests to cover line(s) 47 of `stopAll` | ❌ |  | Audio |
-| trigger | Sources/Audio/TeatroSampler.swift | Add tests to cover line(s) 43 of `trigger` | ❌ |  | Audio |
-| render | Sources/CLI/RenderCLI.swift | Add tests to cover line(s) 191,194,196,199,204,208,213,295,296,297,… of `render` | ❌ |  | CLI |
-| run | Sources/CLI/RenderCLI.swift | Add tests to cover line(s) 57,68,79 of `run` | ❌ |  | CLI |
-| watchFile | Sources/CLI/RenderCLI.swift | Add tests to cover line(s) 249,268,272,282 of `watchFile` | ❌ |  | CLI |
-| build | Sources/MIDI/UMPEncoder.swift | Add tests to cover line(s) 51,52,54,56,57,59,61,62,64,66,… of `build` | ❌ |  | MIDI |
-| encodeEvent | Sources/MIDI/UMPEncoder.swift | Add tests to cover line(s) 40,41 of `encodeEvent` | ❌ |  | MIDI |
-| normalizeController | Sources/Parsers/MidiEvents.swift | Add tests to cover line(s) 127,128,129,137,138,139,140,141,142,143,… of `normalizeController` | ❌ |  | Parsers |
-| parseFile | Sources/Parsers/MidiFileParser.swift | Add tests to cover line(s) 209,213 of `parseFile` | ❌ |  | Parsers |
-| parseHeader | Sources/Parsers/MidiFileParser.swift | Add tests to cover line(s) 25,27 of `parseHeader` | ❌ |  | Parsers |
-| parseTrack | Sources/Parsers/MidiFileParser.swift | Add tests to cover line(s) 38,51,69,82,88,93,100,106,112,116,… of `parseTrack` | ❌ |  | Parsers |
-| readVariableLengthQuantity | Sources/Parsers/MidiFileParser.swift | Add tests to cover line(s) 225 of `readVariableLengthQuantity` | ❌ |  | Parsers |
-| parse | Sources/Parsers/StoryboardParser.swift | Add tests to cover line(s) 33,34,38 of `parse` | ❌ |  | Parsers |
-| decode | Sources/Parsers/UMPParser.swift | Add tests to cover line(s) 65,74,76,81,89,91,115 of `decode` | ❌ |  | Parsers |
-| packetLength | Sources/Parsers/UMPParser.swift | Add tests to cover line(s) 51 of `packetLength` | ❌ |  | Parsers |
-| (global) | Sources/Renderers/ImageRenderer.swift | Add tests to cover line(s) 10,15 of `(global)` | ❌ |  | Renderers |
-| renderToPNG | Sources/Renderers/ImageRenderer.swift | Add tests to cover line(s) 19,50 of `renderToPNG` | ❌ |  | Renderers |
-| render | Sources/Renderers/SVGAnimation/SVGAnimate.swift | Add tests to cover line(s) 17 of `render` | ❌ |  | Renderers |
-| (global) | Sources/Renderers/SVGAnimation/SVGAnimateTransform.swift | Add tests to cover line(s) 7,14 of `(global)` | ❌ |  | Renderers |
-| (global) | Sources/Renderers/SVGAnimation/SVGAnimator.swift | Add tests to cover line(s) 4 of `(global)` | ❌ |  | Renderers |
-| (global) | Sources/Renderers/SVGAnimation/SVGDelta.swift | Add tests to cover line(s) 5,10 of `(global)` | ❌ |  | Renderers |
-| (global) | Sources/Renderers/SVGRenderer.swift | Add tests to cover line(s) 6,11 of `(global)` | ❌ |  | Renderers |
-| parse | Sources/ViewCore/Fountain.swift | Add tests to cover line(s) 26,27,28,31,33 of `parse` | ❌ |  | ViewCore |
-| flush | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 374 of `flush` | ❌ |  | ViewCore |
-| isAllCaps | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 274 of `isAllCaps` | ❌ |  | ViewCore |
-| isParenthetical | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 300 of `isParenthetical` | ❌ |  | ViewCore |
-| isSynopsis | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 319 of `isSynopsis` | ❌ |  | ViewCore |
-| isTransition | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 256,259,260 of `isTransition` | ❌ |  | ViewCore |
-| parse | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 122,124,127,135,140,142,145,151,167,176,… of `parse` | ❌ |  | ViewCore |
-| sectionLevel | Sources/ViewCore/FountainParser.swift | Add tests to cover line(s) 313 of `sectionLevel` | ❌ |  | ViewCore |
-| apply | Sources/ViewCore/Protocols.swift | Add tests to cover line(s) 25 of `apply` | ❌ |  | ViewCore |
+| loadInstrument | Sources/Audio/Samplers/CsoundSampler.swift | Add test that loads a Csound instrument file to cover line 33 | ❌ |  | Audio |
+| deinit | Sources/Audio/Samplers/FluidSynthSampler.swift | Trigger sampler deallocation to cover lines 13,14,15 | ❌ |  | Audio |
+| loadInstrument | Sources/Audio/Samplers/FluidSynthSampler.swift | Load a FluidSynth soundfont to cover lines 23,27,29 | ❌ |  | Audio |
+| noteOff | Sources/Audio/Samplers/FluidSynthSampler.swift | Send note-off event to cover line 54 | ❌ |  | Audio |
+| init | Sources/Audio/TeatroSampler.swift | Initialize sampler with audio client to cover lines 21,22,23,25,27,29,31 | ❌ |  | Audio |
+| render | Sources/CLI/RenderCLI.swift | Execute CLI render with output path to cover lines 191,194,196,199,208,213 | ❌ |  | CLI |
+| run | Sources/CLI/RenderCLI.swift | Run CLI without arguments to cover line 79 | ❌ |  | CLI |
+| watchFile | Sources/CLI/RenderCLI.swift | Watch a file for changes to cover lines 249,268,272,282 | ❌ |  | CLI |
+| encodeEvent | Sources/MIDI/UMPEncoder.swift | Encode diverse MIDI events to cover lines 51,52,56,57,61,62,66,67,71,75,79,83 | ❌ |  | MIDI |
+| MidiEventType | Sources/Parsers/MidiEvents.swift | Exercise all MIDI event types to cover lines 137,151,165,179,196,214,229,244 | ❌ |  | Parsers |
+| parseFile | Sources/Parsers/MidiFileParser.swift | Parse a sample MIDI file to cover lines 209,213 | ❌ |  | Parsers |
+| parseHeader | Sources/Parsers/MidiFileParser.swift | Provide MIDI header bytes to cover lines 25,27 | ❌ |  | Parsers |
+| parseTrack | Sources/Parsers/MidiFileParser.swift | Parse track events to cover lines 38,51,69,82,88,93,100,106,112,116,169,178,182,185,193 | ❌ |  | Parsers |
+| readVariableLengthQuantity | Sources/Parsers/MidiFileParser.swift | Test variable-length quantity parsing for line 225 | ❌ |  | Parsers |
+| decode | Sources/Parsers/UMPParser.swift | Decode UMP packets to cover lines 65,74,76,81,89,91,115 | ❌ |  | Parsers |
+| packetLength | Sources/Parsers/UMPParser.swift | Provide various packet types to cover line 51 | ❌ |  | Parsers |
+| renderToPNG | Sources/Renderers/ImageRenderer.swift | Render a simple view to PNG to cover lines 19,50 | ❌ |  | Renderers |
+| canvasHeight | Sources/Renderers/SVGRenderer.swift | Supply canvas height to cover line 11 | ❌ |  | Renderers |
+| canvasWidth | Sources/Renderers/SVGRenderer.swift | Supply canvas width to cover line 6 | ❌ |  | Renderers |
+| isAllCaps | Sources/ViewCore/FountainParser.swift | Parse uppercase lines to cover line 274 | ❌ |  | ViewCore |
+| isParenthetical | Sources/ViewCore/FountainParser.swift | Parse parenthetical tokens to cover line 300 | ❌ |  | ViewCore |
+| isTransition | Sources/ViewCore/FountainParser.swift | Parse transition lines to cover lines 259,260 | ❌ |  | ViewCore |
+| parse | Sources/ViewCore/FountainParser.swift | Parse a Fountain script to cover lines 122,124,127,135,140,142,145,151,167,176,185,193,195 | ❌ |  | ViewCore |
+| parseInline | Sources/ViewCore/FountainParser.swift | Test inline element parsing for line 374 | ❌ |  | ViewCore |
+| parse | Sources/ViewCore/Fountain.swift | Parse Fountain elements to cover lines 28,33 | ❌ |  | ViewCore |


### PR DESCRIPTION
## Summary
- analyze llvm coverage and generate task matrix for uncovered functions
- document test scenarios needed to improve coverage

## Testing
- `swift test --enable-code-coverage`
- `llvm-profdata-20 merge -sparse .build/debug/codecov/*.profraw -o default.profdata`
- `llvm-cov-20 export .build/debug/teatroPackageTests.xctest -instr-profile=default.profdata > coverage.json`


------
https://chatgpt.com/codex/tasks/task_b_68936fd0c48c8333a78ad0884e57d4f4