### PR TITLE
Add coverage tests for sampler backends and CLI outputs

### DIFF
--- a/Tests/CLI/RenderCLICoverageTests.swift
+++ b/Tests/CLI/RenderCLICoverageTests.swift
@@ -124,6 +124,25 @@ final class RenderCLICoverageTests: XCTestCase {
         XCTAssertTrue(contents.contains("<svg"))
     }
 
+    func testPNGOutputWritesFile() throws {
+        let url = tempURL("out.png")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cli = try RenderCLI.parse(["--format", "png", "--output", url.path])
+        XCTAssertNoThrow(try cli.run())
+        if !FileManager.default.fileExists(atPath: url.path) {
+            let alt = url.deletingPathExtension().appendingPathExtension("svg")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: alt.path))
+        }
+    }
+
+    func testMarkdownOutputWritesFile() throws {
+        let url = tempURL("out.md")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let cli = try RenderCLI.parse(["--format", "markdown", "--output", url.path])
+        XCTAssertNoThrow(try cli.run())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
     func testSvgAnimatedStoryboardRenders() throws {
         let text = """
         Scene: One
@@ -167,6 +186,11 @@ final class RenderCLICoverageTests: XCTestCase {
             try cli.run()
         }
         XCTAssertFalse(output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    func testRunWithoutArguments() throws {
+        let cli = try RenderCLI.parse([])
+        XCTAssertNoThrow(try cli.run())
     }
 
     func testRunAppliesWidthAndHeightOptions() throws {

--- a/Tests/SamplerTests/TeatroSamplerTests.swift
+++ b/Tests/SamplerTests/TeatroSamplerTests.swift
@@ -40,4 +40,16 @@ final class TeatroSamplerTests: XCTestCase {
         let stopped = await mock.didStop()
         XCTAssertTrue(stopped)
     }
+
+    func testInitWithFluidSynthBackend() async throws {
+        let path = FileManager.default.currentDirectoryPath + "/assets/example.sf2"
+        let sampler = try await TeatroSampler(backend: .fluidsynth(sf2Path: path))
+        await sampler.stopAll()
+    }
+
+    func testInitWithCsoundBackend() async throws {
+        let path = FileManager.default.currentDirectoryPath + "/assets/sine.orc"
+        let sampler = try await TeatroSampler(backend: .csound(orchestra: path))
+        await sampler.stopAll()
+    }
 }


### PR DESCRIPTION
## Summary
- add sampler backend initialization tests to ensure instruments load
- add PNG and Markdown output tests and run without arguments for RenderCLI

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68937b78a52883338828de209297b80f