### PR TITLE
Introduce layout AST and SVG renderer support

### DIFF
--- a/Docs/Chapters/01_CoreProtocols.md
+++ b/Docs/Chapters/01_CoreProtocols.md
@@ -3,11 +3,15 @@ _A foundation for building every view type._
 
 ### 1.1 Renderable
 
-The foundational protocol of the Teatro View Engine. All visual, narrative, or musical view types conform to `Renderable`, ensuring a consistent `.render()` interface for Codex control, preview rendering, or export.
+The foundational protocol of the Teatro View Engine. All visual, narrative, or musical view types conform to `Renderable`, exposing a structured layout tree via `layout()`. A default `render()` method remains for legacy text-based workflows.
 
 ```swift
 public protocol Renderable {
-    func render() -> String
+    func layout() -> LayoutNode
+}
+
+public extension Renderable {
+    func render() -> String { layout().toText() }
 }
 ```
 

--- a/Sources/CLI/RenderCLI.swift
+++ b/Sources/CLI/RenderCLI.swift
@@ -286,8 +286,8 @@ public struct RenderCLI: ParsableCommand {
 struct MidiEventView: Renderable {
     let events: [any MidiEventProtocol]
 
-    func render() -> String {
-        events.map { event in
+    func layout() -> LayoutNode {
+        let lines = events.map { event -> String in
             var parts: [String] = ["t\(event.timestamp)"]
             if let ch = event.channel { parts.append("ch\(ch)") }
             switch event.type {
@@ -315,6 +315,7 @@ struct MidiEventView: Renderable {
             }
             return parts.joined(separator: " ")
         }.joined(separator: "\n")
+        return .raw(lines)
     }
 }
 

--- a/Sources/Parsers/SessionParser.swift
+++ b/Sources/Parsers/SessionParser.swift
@@ -22,8 +22,8 @@ public struct Session: Renderable {
     }
 
     /// Renders the session as plain text.
-    public func render() -> String {
-        text
+    public func layout() -> LayoutNode {
+        .raw(text)
     }
 }
 

--- a/Sources/Parsers/StoryboardParser.swift
+++ b/Sources/Parsers/StoryboardParser.swift
@@ -51,8 +51,8 @@ public extension Storyboard {
 }
 
 extension Storyboard: Renderable {
-    public func render() -> String {
-        CodexStoryboardPreviewer.prompt(self)
+    public func layout() -> LayoutNode {
+        .raw(CodexStoryboardPreviewer.prompt(self))
     }
 }
 

--- a/Sources/Renderers/CodexPreviewer.swift
+++ b/Sources/Renderers/CodexPreviewer.swift
@@ -7,7 +7,7 @@ public struct CodexPreviewer {
         /// \(String(describing: type(of: view)))
         ///
         /// Output:
-        \(view.render())
+        \(view.layout().toText())
         """
     }
 }

--- a/Sources/Renderers/HTMLRenderer.swift
+++ b/Sources/Renderers/HTMLRenderer.swift
@@ -1,5 +1,5 @@
 public struct HTMLRenderer {
     public static func render(_ view: Renderable) -> String {
-        "<html><body><pre>\n" + view.render() + "\n</pre></body></html>"
+        "<html><body><pre>\n" + view.layout().toText() + "\n</pre></body></html>"
     }
 }

--- a/Sources/Renderers/MarkdownRenderer.swift
+++ b/Sources/Renderers/MarkdownRenderer.swift
@@ -1,5 +1,5 @@
 public struct MarkdownRenderer {
     public static func render(_ view: Renderable) -> String {
-        "```\n" + view.render() + "\n```"
+        "```\n" + view.layout().toText() + "\n```"
     }
 }

--- a/Sources/Renderers/SVGRenderer.swift
+++ b/Sources/Renderers/SVGRenderer.swift
@@ -18,9 +18,20 @@ public struct SVGRenderer {
         if let cached = cache[key] { return cached }
 
         var y = 20
-        let rendered = view.render().components(separatedBy: "\n").map { line -> String in
+        let rendered = view.layout().lines().map { line -> String in
             defer { y += 20 }
-            let styled = applyStyle(line)
+            let styled = line.map { span -> String in
+                switch span.style {
+                case .bold:
+                    return "<tspan font-weight=\"bold\">\(span.text)</tspan>"
+                case .italic:
+                    return "<tspan font-style=\"italic\">\(span.text)</tspan>"
+                case .underline:
+                    return "<tspan text-decoration=\"underline\">\(span.text)</tspan>"
+                case .plain:
+                    return span.text
+                }
+            }.joined()
             return "<text x=\"10\" y=\"\(y)\" font-family=\"monospace\" font-size=\"14\">\(styled)</text>"
         }.joined(separator: "\n")
 
@@ -32,19 +43,5 @@ public struct SVGRenderer {
 
         cache[key] = svg
         return svg
-    }
-
-    private static func applyStyle(_ line: String) -> String {
-        var result = line
-        result = result.replacing("\\*\\*(.+?)\\*\\*", with: "<tspan font-weight=\"bold\">$1</tspan>")
-        result = result.replacing("\\*(.+?)\\*", with: "<tspan font-style=\"italic\">$1</tspan>")
-        result = result.replacing("_(.+?)_", with: "<tspan text-decoration=\"underline\">$1</tspan>")
-        return result
-    }
-}
-
-private extension String {
-    func replacing(_ pattern: String, with template: String) -> String {
-        replacingOccurrences(of: pattern, with: template, options: .regularExpression)
     }
 }

--- a/Sources/ViewCore/CsoundScore.swift
+++ b/Sources/ViewCore/CsoundScore.swift
@@ -9,8 +9,8 @@ public struct CsoundScore: Renderable {
         self.score = score
     }
 
-    public func render() -> String {
-        """
+    public func layout() -> LayoutNode {
+        .raw("""
         <CsoundSynthesizer>
         <Orchestra>
         \(orchestra)
@@ -19,6 +19,6 @@ public struct CsoundScore: Renderable {
         \(score)
         </Score>
         </CsoundSynthesizer>
-        """
+        """)
     }
 }

--- a/Sources/ViewCore/DispatcherPrompt.swift
+++ b/Sources/ViewCore/DispatcherPrompt.swift
@@ -5,7 +5,7 @@ typealias HorizontalAlignment = Alignment
 public struct DispatcherPrompt: Renderable {
     public init() {}
 
-    public func render() -> String {
+    public func layout() -> LayoutNode {
         Stage(title: "Dispatcher") {
             Panel(width: 640, height: 900, cornerRadius: 12) {
                 VStack(alignment: HorizontalAlignment.leading) {
@@ -16,6 +16,6 @@ public struct DispatcherPrompt: Renderable {
                     InputCursor()
                 }
             }
-        }.render()
+        }.layout()
     }
 }

--- a/Sources/ViewCore/Dot.swift
+++ b/Sources/ViewCore/Dot.swift
@@ -9,7 +9,7 @@ public struct Dot: Renderable {
         self.diameter = diameter
     }
 
-    public func render() -> String {
-        "\u{25CF}" // ●
+    public func layout() -> LayoutNode {
+        .raw("\u{25CF}")
     }
 }

--- a/Sources/ViewCore/Fountain.swift
+++ b/Sources/ViewCore/Fountain.swift
@@ -5,13 +5,13 @@ public enum FountainElement: Renderable {
     case action(String)
     case transition(String)
 
-    public func render() -> String {
+    public func layout() -> LayoutNode {
         switch self {
-        case .sceneHeading(let txt): return "# \(txt)"
-        case .characterCue(let txt): return "\n\(txt.uppercased())"
-        case .dialogue(let txt): return "\t\(txt)"
-        case .action(let txt): return txt
-        case .transition(let txt): return "\(txt) >>"
+        case .sceneHeading(let txt): return .raw("# \(txt)")
+        case .characterCue(let txt): return .raw("\n\(txt.uppercased())")
+        case .dialogue(let txt): return .raw("\t\(txt)")
+        case .action(let txt): return .raw(txt)
+        case .transition(let txt): return .raw("\(txt) >>")
         }
     }
 }
@@ -44,7 +44,7 @@ public struct FountainSceneView: Renderable {
         self.elements = FountainRenderer.parse(fountainText)
     }
 
-    public func render() -> String {
-        elements.map { $0.render() }.joined(separator: "\n")
+    public func layout() -> LayoutNode {
+        .raw(elements.map { $0.layout().toText() }.joined(separator: "\n"))
     }
 }

--- a/Sources/ViewCore/HStack.swift
+++ b/Sources/ViewCore/HStack.swift
@@ -9,8 +9,7 @@ public struct HStack: Layouting {
         self.children = content()
     }
 
-    public func render() -> String {
-        let indent = String(repeating: " ", count: padding)
-        return indent + children.map { $0.render() }.joined(separator: " ")
+    public func layout() -> LayoutNode {
+        .hStack(alignment: alignment, padding: padding, children: children.map { $0.layout() })
     }
 }

--- a/Sources/ViewCore/InputCursor.swift
+++ b/Sources/ViewCore/InputCursor.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct InputCursor: Renderable {
     public init() {}
 
-    public func render() -> String {
-        "|"
+    public func layout() -> LayoutNode {
+        .raw("|")
     }
 }

--- a/Sources/ViewCore/LayoutNode.swift
+++ b/Sources/ViewCore/LayoutNode.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public indirect enum LayoutNode {
+    case text(String, style: TextStyle)
+    case hStack(alignment: Alignment, padding: Int, children: [LayoutNode])
+    case vStack(alignment: Alignment, padding: Int, children: [LayoutNode])
+    case panel(width: Int, height: Int, cornerRadius: Int, children: [LayoutNode])
+    case stage(title: String, child: LayoutNode)
+    case raw(String)
+}
+
+public struct TextSpan {
+    public let text: String
+    public let style: TextStyle
+}
+
+public extension LayoutNode {
+    func lines() -> [[TextSpan]] {
+        switch self {
+        case .text(let content, let style):
+            return [[TextSpan(text: content, style: style)]]
+        case .raw(let str):
+            return str.components(separatedBy: "\n").map { [TextSpan(text: $0, style: .plain)] }
+        case .hStack(_, let padding, let children):
+            let indent = TextSpan(text: String(repeating: " ", count: padding), style: .plain)
+            var line: [TextSpan] = [indent]
+            for (i, child) in children.enumerated() {
+                if i > 0 { line.append(TextSpan(text: " ", style: .plain)) }
+                let childLine = child.lines().first ?? []
+                line.append(contentsOf: childLine)
+            }
+            return [line]
+        case .vStack(_, let padding, let children):
+            let indent = TextSpan(text: String(repeating: " ", count: padding), style: .plain)
+            var result: [[TextSpan]] = []
+            for child in children {
+                for line in child.lines() {
+                    result.append([indent] + line)
+                }
+            }
+            return result
+        case .panel(let width, let height, let cornerRadius, let children):
+            var result: [[TextSpan]] = [[TextSpan(text: "[Panel \(width)x\(height) r:\(cornerRadius)]", style: .plain)]]
+            for child in children {
+                result.append(contentsOf: child.lines())
+            }
+            return result
+        case .stage(let title, let child):
+            var result: [[TextSpan]] = [[TextSpan(text: "[Stage: \(title)]", style: .plain)]]
+            result.append(contentsOf: child.lines())
+            return result
+        }
+    }
+
+    func toText() -> String {
+        lines().map { line in
+            line.map { $0.style.apply(to: $0.text) }.joined()
+        }.joined(separator: "\n")
+    }
+
+    static func legacy(_ text: String) -> LayoutNode {
+        .raw(text)
+    }
+}
+
+public struct LegacyText: Renderable {
+    public let text: String
+    public init(_ text: String) { self.text = text }
+    public func layout() -> LayoutNode { .raw(text) }
+}

--- a/Sources/ViewCore/LilyScore.swift
+++ b/Sources/ViewCore/LilyScore.swift
@@ -7,8 +7,8 @@ public struct LilyScore: Renderable {
         self.content = content
     }
 
-    public func render() -> String {
-        content
+    public func layout() -> LayoutNode {
+        .raw(content)
     }
 
     public func renderToPDF(filename: String = "score") {

--- a/Sources/ViewCore/Panel.swift
+++ b/Sources/ViewCore/Panel.swift
@@ -13,7 +13,7 @@ public struct Panel: Renderable {
         self.content = content()
     }
 
-    public func render() -> String {
-        "[Panel \(width)x\(height) r:\(cornerRadius)]\n" + content.map { $0.render() }.joined(separator: "\n")
+    public func layout() -> LayoutNode {
+        .panel(width: width, height: height, cornerRadius: cornerRadius, children: content.map { $0.layout() })
     }
 }

--- a/Sources/ViewCore/Protocols.swift
+++ b/Sources/ViewCore/Protocols.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 public protocol Renderable {
-    func render() -> String
+    func layout() -> LayoutNode
+}
+
+public extension Renderable {
+    func render() -> String { layout().toText() }
 }
 
 public protocol Layouting: Renderable {

--- a/Sources/ViewCore/Rule.swift
+++ b/Sources/ViewCore/Rule.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct Rule: Renderable {
     public init() {}
 
-    public func render() -> String {
-        String(repeating: "-", count: 10)
+    public func layout() -> LayoutNode {
+        .raw(String(repeating: "-", count: 10))
     }
 }

--- a/Sources/ViewCore/Stage.swift
+++ b/Sources/ViewCore/Stage.swift
@@ -7,7 +7,7 @@ public struct Stage: Renderable {
         self.content = content()
     }
 
-    public func render() -> String {
-        "[Stage: \(title)]\n" + content.render()
+    public func layout() -> LayoutNode {
+        .stage(title: title, child: content.layout())
     }
 }

--- a/Sources/ViewCore/TeatroIcon.swift
+++ b/Sources/ViewCore/TeatroIcon.swift
@@ -5,7 +5,7 @@ public struct TeatroIcon: Renderable {
         self.symbol = symbol
     }
 
-    public func render() -> String {
-        "\u{25C9} \(symbol)" // use ◉ (U+25C9)
+    public func layout() -> LayoutNode {
+        .raw("\u{25C9} \(symbol)")
     }
 }

--- a/Sources/ViewCore/Text.swift
+++ b/Sources/ViewCore/Text.swift
@@ -7,7 +7,7 @@ public struct Text: Renderable {
         self.style = style
     }
 
-    public func render() -> String {
-        style.apply(to: content)
+    public func layout() -> LayoutNode {
+        .text(content, style: style)
     }
 }

--- a/Sources/ViewCore/VStack.swift
+++ b/Sources/ViewCore/VStack.swift
@@ -9,8 +9,7 @@ public struct VStack: Layouting {
         self.children = content()
     }
 
-    public func render() -> String {
-        let indent = String(repeating: " ", count: padding)
-        return children.map { indent + $0.render() }.joined(separator: "\n")
+    public func layout() -> LayoutNode {
+        .vStack(alignment: alignment, padding: padding, children: children.map { $0.layout() })
     }
 }

--- a/Tests/AnimatorTests.swift
+++ b/Tests/AnimatorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class AnimatorTests: XCTestCase {
     func testRenderFramesCreatesFiles() async {
         struct Dummy: Renderable {
-            func render() -> String { "Hello" }
+            func layout() -> LayoutNode { .text("Hello", style: .plain) }
         }
         let base = "test_frame"
         let fileManager = FileManager.default


### PR DESCRIPTION
## Summary
- add `LayoutNode` intermediate representation and legacy text adapter
- update views and renderers to use structured layout
- document new `Renderable.layout()` workflow

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68942604360c8333b2170b7a52e92efd