### PR TITLE
Enhance stack layouts with spacing, distribution, and ZStack support

### DIFF
--- a/Sources/ViewCore/HStack.swift
+++ b/Sources/ViewCore/HStack.swift
@@ -1,15 +1,31 @@
 public struct HStack: Layouting {
     public let children: [Renderable]
     public let alignment: Alignment
+    public let spacing: Int
+    public let distribution: Distribution
     public let padding: Int
 
-    public init(alignment: Alignment = Alignment.leading, padding: Int = 0, @ViewBuilder _ content: () -> [Renderable]) {
+    public init(
+        alignment: Alignment = .leading,
+        spacing: Int = 1,
+        distribution: Distribution = .leading,
+        padding: Int = 0,
+        @ViewBuilder _ content: () -> [Renderable]
+    ) {
         self.alignment = alignment
+        self.spacing = spacing
+        self.distribution = distribution
         self.padding = padding
         self.children = content()
     }
 
     public func layout() -> LayoutNode {
-        .hStack(alignment: alignment, padding: padding, children: children.map { $0.layout() })
+        .hStack(
+            alignment: alignment,
+            spacing: spacing,
+            distribution: distribution,
+            padding: padding,
+            children: children.map { $0.layout() }
+        )
     }
 }

--- a/Sources/ViewCore/LayoutNode.swift
+++ b/Sources/ViewCore/LayoutNode.swift
@@ -2,8 +2,9 @@ import Foundation
 
 public indirect enum LayoutNode {
     case text(String, style: TextStyle)
-    case hStack(alignment: Alignment, padding: Int, children: [LayoutNode])
-    case vStack(alignment: Alignment, padding: Int, children: [LayoutNode])
+    case hStack(alignment: Alignment, spacing: Int, distribution: Distribution, padding: Int, children: [LayoutNode])
+    case vStack(alignment: Alignment, spacing: Int, distribution: Distribution, padding: Int, children: [LayoutNode])
+    case zStack(children: [LayoutNode])
     case panel(width: Int, height: Int, cornerRadius: Int, children: [LayoutNode])
     case stage(title: String, child: LayoutNode)
     case raw(String)
@@ -21,24 +22,65 @@ public extension LayoutNode {
             return [[TextSpan(text: content, style: style)]]
         case .raw(let str):
             return str.components(separatedBy: "\n").map { [TextSpan(text: $0, style: .plain)] }
-        case .hStack(_, let padding, let children):
+        case .hStack(_, let spacing, let distribution, let padding, let children):
             let indent = TextSpan(text: String(repeating: " ", count: padding), style: .plain)
             var line: [TextSpan] = [indent]
+            let leadingSpaces = distribution == .trailing ? spacing : (distribution == .center ? spacing / 2 : 0)
+            let trailingSpaces = distribution == .center ? spacing / 2 : 0
+            if leadingSpaces > 0 {
+                line.append(TextSpan(text: String(repeating: " ", count: leadingSpaces), style: .plain))
+            }
             for (i, child) in children.enumerated() {
-                if i > 0 { line.append(TextSpan(text: " ", style: .plain)) }
+                if i > 0 {
+                    line.append(TextSpan(text: String(repeating: " ", count: spacing), style: .plain))
+                }
                 let childLine = child.lines().first ?? []
                 line.append(contentsOf: childLine)
             }
+            if trailingSpaces > 0 {
+                line.append(TextSpan(text: String(repeating: " ", count: trailingSpaces), style: .plain))
+            }
             return [line]
-        case .vStack(_, let padding, let children):
+        case .vStack(_, let spacing, let distribution, let padding, let children):
             let indent = TextSpan(text: String(repeating: " ", count: padding), style: .plain)
             var result: [[TextSpan]] = []
-            for child in children {
+            let topSpacing = distribution == .trailing ? spacing : (distribution == .center ? spacing : 0)
+            let bottomSpacing = distribution == .center ? spacing : 0
+            if topSpacing > 0 {
+                result.append(contentsOf: Array(repeating: [indent], count: topSpacing))
+            }
+            for (i, child) in children.enumerated() {
                 for line in child.lines() {
                     result.append([indent] + line)
                 }
+                if i < children.count - 1 && spacing > 0 {
+                    result.append(contentsOf: Array(repeating: [indent], count: spacing))
+                }
+            }
+            if bottomSpacing > 0 {
+                result.append(contentsOf: Array(repeating: [indent], count: bottomSpacing))
             }
             return result
+        case .zStack(let children):
+            let childStrings = children.map { $0.toText().components(separatedBy: "\n") }
+            let maxLines = childStrings.map { $0.count }.max() ?? 0
+            var resultLines: [String] = Array(repeating: "", count: maxLines)
+            func overlay(_ base: String, _ top: String) -> String {
+                let width = max(base.count, top.count)
+                var chars = Array(repeating: Character(" "), count: width)
+                let baseChars = Array(base)
+                let topChars = Array(top)
+                for i in 0..<baseChars.count { chars[i] = baseChars[i] }
+                for i in 0..<topChars.count { if topChars[i] != " " { chars[i] = topChars[i] } }
+                return String(chars)
+            }
+            for lines in childStrings {
+                for i in 0..<maxLines {
+                    let topLine = i < lines.count ? lines[i] : ""
+                    resultLines[i] = overlay(resultLines[i], topLine)
+                }
+            }
+            return resultLines.map { [TextSpan(text: $0, style: .plain)] }
         case .panel(let width, let height, let cornerRadius, let children):
             var result: [[TextSpan]] = [[TextSpan(text: "[Panel \(width)x\(height) r:\(cornerRadius)]", style: .plain)]]
             for child in children {

--- a/Sources/ViewCore/Protocols.swift
+++ b/Sources/ViewCore/Protocols.swift
@@ -19,6 +19,10 @@ public enum Alignment: String {
     case trailing = "right"
 }
 
+public enum Distribution {
+    case leading, center, trailing
+}
+
 public enum TextStyle {
     case bold, italic, underline, plain
 

--- a/Sources/ViewCore/VStack.swift
+++ b/Sources/ViewCore/VStack.swift
@@ -1,15 +1,31 @@
 public struct VStack: Layouting {
     public let children: [Renderable]
     public let alignment: Alignment
+    public let spacing: Int
+    public let distribution: Distribution
     public let padding: Int
 
-    public init(alignment: Alignment = Alignment.leading, padding: Int = 0, @ViewBuilder _ content: () -> [Renderable]) {
+    public init(
+        alignment: Alignment = .leading,
+        spacing: Int = 0,
+        distribution: Distribution = .leading,
+        padding: Int = 0,
+        @ViewBuilder _ content: () -> [Renderable]
+    ) {
         self.alignment = alignment
+        self.spacing = spacing
+        self.distribution = distribution
         self.padding = padding
         self.children = content()
     }
 
     public func layout() -> LayoutNode {
-        .vStack(alignment: alignment, padding: padding, children: children.map { $0.layout() })
+        .vStack(
+            alignment: alignment,
+            spacing: spacing,
+            distribution: distribution,
+            padding: padding,
+            children: children.map { $0.layout() }
+        )
     }
 }

--- a/Sources/ViewCore/ZStack.swift
+++ b/Sources/ViewCore/ZStack.swift
@@ -1,0 +1,10 @@
+// Overlays child views, as requested by root AGENT guidelines.
+public struct ZStack: Renderable {
+    public let children: [Renderable]
+    public init(@ViewBuilder _ content: () -> [Renderable]) {
+        self.children = content()
+    }
+    public func layout() -> LayoutNode {
+        .zStack(children: children.map { $0.layout() })
+    }
+}

--- a/Tests/ViewCoreTests.swift
+++ b/Tests/ViewCoreTests.swift
@@ -24,6 +24,30 @@ final class ViewCoreTests: XCTestCase {
         XCTAssertEqual(stack.render(), " A B")
     }
 
+    func testVStackSpacing() {
+        let stack = VStack(spacing: 1) {
+            Text("A")
+            Text("B")
+        }
+        XCTAssertEqual(stack.render(), "A\n\nB")
+    }
+
+    func testHStackSpacingAndDistribution() {
+        let stack = HStack(spacing: 2, distribution: .center) {
+            Text("A")
+            Text("B")
+        }
+        XCTAssertEqual(stack.render(), " A  B ")
+    }
+
+    func testZStackRendering() {
+        let stack = ZStack {
+            Text("A")
+            Text("B")
+        }
+        XCTAssertEqual(stack.render(), "B")
+    }
+
     func testPanelRendering() {
         let panel = Panel(width: 100, height: 100, cornerRadius: 5) {
             Text("X")


### PR DESCRIPTION
## Summary
- add a `Distribution` enum to configure stack child placement
- extend `VStack` and `HStack` with configurable spacing and distribution
- introduce `ZStack` for overlapping layouts
- cover new layout behaviors in `ViewCoreTests`

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689429db8b488333ad197b6b8e2f2532