### PR TITLE
feat: centralize style expansion for renderers

### DIFF
--- a/Sources/Renderers/HTMLRenderer.swift
+++ b/Sources/Renderers/HTMLRenderer.swift
@@ -1,5 +1,6 @@
 public struct HTMLRenderer {
     public static func render(_ view: Renderable) -> String {
-        "<html><body><pre>\n" + view.layout().toText() + "\n</pre></body></html>"
+        let body = view.layout().lines().map { StyleExpander.html($0) }.joined(separator: "\n")
+        return "<html><body><pre>\n" + body + "\n</pre></body></html>"
     }
 }

--- a/Sources/Renderers/MarkdownRenderer.swift
+++ b/Sources/Renderers/MarkdownRenderer.swift
@@ -1,5 +1,6 @@
 public struct MarkdownRenderer {
     public static func render(_ view: Renderable) -> String {
-        "```\n" + view.layout().toText() + "\n```"
+        let body = view.layout().lines().map { StyleExpander.markdown($0) }.joined(separator: "\n")
+        return "```\n" + body + "\n```"
     }
 }

--- a/Sources/Renderers/SVGRenderer.swift
+++ b/Sources/Renderers/SVGRenderer.swift
@@ -20,18 +20,7 @@ public struct SVGRenderer {
         var y = 20
         let rendered = view.layout().lines().map { line -> String in
             defer { y += 20 }
-            let styled = line.map { span -> String in
-                switch span.style {
-                case .bold:
-                    return "<tspan font-weight=\"bold\">\(span.text)</tspan>"
-                case .italic:
-                    return "<tspan font-style=\"italic\">\(span.text)</tspan>"
-                case .underline:
-                    return "<tspan text-decoration=\"underline\">\(span.text)</tspan>"
-                case .plain:
-                    return span.text
-                }
-            }.joined()
+            let styled = StyleExpander.svg(line)
             return "<text x=\"10\" y=\"\(y)\" font-family=\"monospace\" font-size=\"14\">\(styled)</text>"
         }.joined(separator: "\n")
 

--- a/Sources/ViewCore/LayoutNode.swift
+++ b/Sources/ViewCore/LayoutNode.swift
@@ -95,9 +95,7 @@ public extension LayoutNode {
     }
 
     func toText() -> String {
-        lines().map { line in
-            line.map { $0.style.apply(to: $0.text) }.joined()
-        }.joined(separator: "\n")
+        lines().map { StyleExpander.markdown($0) }.joined(separator: "\n")
     }
 
     static func legacy(_ text: String) -> LayoutNode {

--- a/Sources/ViewCore/StyleExpander.swift
+++ b/Sources/ViewCore/StyleExpander.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Shared helpers for expanding `TextSpan` style information.
+public enum StyleExpander {
+    public static func expand(_ spans: [TextSpan], using mapper: (TextStyle, String) -> String) -> String {
+        spans.map { mapper($0.style, $0.text) }.joined()
+    }
+
+    public static func markdown(_ spans: [TextSpan]) -> String {
+        expand(spans) { style, text in
+            switch style {
+            case .bold:
+                return "**\(text)**"
+            case .italic:
+                return "*\(text)*"
+            case .underline:
+                return "_\(text)_"
+            case .plain:
+                return text
+            }
+        }
+    }
+
+    public static func html(_ spans: [TextSpan]) -> String {
+        expand(spans) { style, text in
+            switch style {
+            case .bold:
+                return "<strong>\(text)</strong>"
+            case .italic:
+                return "<em>\(text)</em>"
+            case .underline:
+                return "<u>\(text)</u>"
+            case .plain:
+                return text
+            }
+        }
+    }
+
+    public static func svg(_ spans: [TextSpan]) -> String {
+        expand(spans) { style, text in
+            switch style {
+            case .bold:
+                return "<tspan font-weight=\"bold\">\(text)</tspan>"
+            case .italic:
+                return "<tspan font-style=\"italic\">\(text)</tspan>"
+            case .underline:
+                return "<tspan text-decoration=\"underline\">\(text)</tspan>"
+            case .plain:
+                return text
+            }
+        }
+    }
+}
+

--- a/Tests/RendererTests.swift
+++ b/Tests/RendererTests.swift
@@ -8,6 +8,12 @@ final class RendererTests: XCTestCase {
         XCTAssertTrue(html.contains("<pre>\nHi\n</pre>"))
     }
 
+    func testHTMLRendererStyles() {
+        let text = Text("B", style: .bold)
+        let html = HTMLRenderer.render(text)
+        XCTAssertTrue(html.contains("<strong>B</strong>"))
+    }
+
     func testSVGRenderer() {
         let text = Text("Hi")
         let svg = SVGRenderer.render(text)
@@ -15,11 +21,23 @@ final class RendererTests: XCTestCase {
         XCTAssertTrue(svg.contains("Hi"))
     }
 
+    func testSVGRendererStyles() {
+        let text = Text("U", style: .underline)
+        let svg = SVGRenderer.render(text)
+        XCTAssertTrue(svg.contains("text-decoration=\"underline\""))
+    }
+
     func testMarkdownRenderer() {
         let text = Text("Hi")
         let md = MarkdownRenderer.render(text)
         XCTAssertTrue(md.contains("```"))
         XCTAssertTrue(md.contains("Hi"))
+    }
+
+    func testMarkdownRendererStyles() {
+        let text = Text("I", style: .italic)
+        let md = MarkdownRenderer.render(text)
+        XCTAssertTrue(md.contains("*I*"))
     }
 
     func testAnimatedSVGRenderer() {


### PR DESCRIPTION
## Summary
- add reusable `StyleExpander` for Markdown/HTML/SVG text spans
- renderers now format pre-styled segments via `StyleExpander`
- document shared expander and cover style-specific rendering in tests

## Testing
- `swift test`
- `swift run --repl` benchmark of `SVGRenderer.render`

------
https://chatgpt.com/codex/tasks/task_b_68942be87a588333ad6f635be1107aa5