### PR TITLE
Add structured parser errors and expose context in CLI

### DIFF
--- a/Sources/CLI/RenderCLI.swift
+++ b/Sources/CLI/RenderCLI.swift
@@ -141,10 +141,18 @@ public struct RenderCLI: ParsableCommand {
             return LilyScore(text)
         case "csd":
             let text = String(decoding: fileData, as: UTF8.self)
-            return try CSDParser.parse(text)
+            do {
+                return try CSDParser.parse(text)
+            } catch let err as ParserError {
+                throw ValidationError(formatParserError(err, path: path))
+            }
         case "storyboard":
             let text = String(decoding: fileData, as: UTF8.self)
-            return StoryboardParser.parse(text)
+            do {
+                return try StoryboardParser.parse(text)
+            } catch let err as ParserError {
+                throw ValidationError(formatParserError(err, path: path))
+            }
         case "mid", "midi":
             let events = try parseMidiFile(data: fileData)
             return MidiEventView(events: events)
@@ -165,6 +173,10 @@ public struct RenderCLI: ParsableCommand {
                 throw ValidationError("Unsupported input extension: .\(ext)")
             }
         }
+    }
+
+    private func formatParserError(_ error: ParserError, path: String) -> String {
+        "\(path):\(error.line):\(error.column): \(error.message)\n\(error.snippet)"
     }
 
     private func parseMidiFile(data: Data) throws -> [any MidiEventProtocol] {

--- a/Sources/Parsers/CSDParser.swift
+++ b/Sources/Parsers/CSDParser.swift
@@ -1,21 +1,16 @@
 import Foundation
 
 /// Parser for Csound .csd files.
-public enum CSDParserError: Error {
-    case missingOrchestra
-    case missingScore
-}
-
 public struct CSDParser {
     /// Parses a Csound CSD document into a `CsoundScore`.
     /// - Parameter text: Full text of the .csd file.
     /// - Returns: A `CsoundScore` containing orchestra and score sections.
     public static func parse(_ text: String) throws -> CsoundScore {
         guard let orchestra = extract(tag: "Orchestra", from: text) else {
-            throw CSDParserError.missingOrchestra
+            throw ParserError(message: "Missing <Orchestra> section", text: text, index: text.startIndex)
         }
         guard let score = extract(tag: "Score", from: text) else {
-            throw CSDParserError.missingScore
+            throw ParserError(message: "Missing <Score> section", text: text, index: text.startIndex)
         }
         return CsoundScore(orchestra: orchestra, score: score)
     }

--- a/Sources/Parsers/ParserError.swift
+++ b/Sources/Parsers/ParserError.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Represents a parsing error with location and context information.
+public struct ParserError: Error, CustomStringConvertible {
+    /// Human-readable message describing the error.
+    public let message: String
+    /// Byte offset of the error in the source text.
+    public let offset: Int
+    /// Line number (1-based) where the error occurred.
+    public let line: Int
+    /// Column number (1-based) where the error occurred.
+    public let column: Int
+    /// Snippet of the source surrounding the error with a caret indicator.
+    public let snippet: String
+
+    public var description: String {
+        "\(message) at line \(line), column \(column)\n\(snippet)"
+    }
+
+    /// Creates a new parser error given a message, source text, and error index.
+    /// - Parameters:
+    ///   - message: Description of the failure.
+    ///   - text: Full source text being parsed.
+    ///   - index: Index within `text` where the error occurred.
+    public init(message: String, text: String, index: String.Index) {
+        self.message = message
+        self.offset = text.distance(from: text.startIndex, to: index)
+        var lineNumber = 1
+        var columnNumber = 1
+        var lineStart = text.startIndex
+        var i = text.startIndex
+        while i < index {
+            if text[i] == "\n" {
+                lineNumber += 1
+                columnNumber = 1
+                lineStart = text.index(after: i)
+            } else {
+                columnNumber += 1
+            }
+            i = text.index(after: i)
+        }
+        self.line = lineNumber
+        self.column = columnNumber
+        let lineEnd = text[lineStart...].firstIndex(of: "\n") ?? text.endIndex
+        let lineText = String(text[lineStart..<lineEnd])
+        let caret = String(repeating: " ", count: columnNumber - 1) + "^"
+        self.snippet = lineText + "\n" + caret
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/CSDParserTests.swift
+++ b/Tests/CSDParserTests.swift
@@ -25,7 +25,8 @@ final class CSDParserTests: XCTestCase {
         </CsoundSynthesizer>
         """
         XCTAssertThrowsError(try CSDParser.parse(csdMissingOrchestra)) { error in
-            XCTAssertEqual(error as? CSDParserError, .missingOrchestra)
+            guard let parseError = error as? ParserError else { return XCTFail("Expected ParserError") }
+            XCTAssertTrue(parseError.message.contains("Orchestra"))
         }
         let csdMissingScore = """
         <CsoundSynthesizer>
@@ -33,7 +34,8 @@ final class CSDParserTests: XCTestCase {
         </CsoundSynthesizer>
         """
         XCTAssertThrowsError(try CSDParser.parse(csdMissingScore)) { error in
-            XCTAssertEqual(error as? CSDParserError, .missingScore)
+            guard let parseError = error as? ParserError else { return XCTFail("Expected ParserError") }
+            XCTAssertTrue(parseError.message.contains("Score"))
         }
         let csdUnclosedOrchestra = """
         <CsoundSynthesizer>
@@ -42,7 +44,8 @@ final class CSDParserTests: XCTestCase {
         </CsoundSynthesizer>
         """
         XCTAssertThrowsError(try CSDParser.parse(csdUnclosedOrchestra)) { error in
-            XCTAssertEqual(error as? CSDParserError, .missingOrchestra)
+            guard let parseError = error as? ParserError else { return XCTFail("Expected ParserError") }
+            XCTAssertTrue(parseError.message.contains("Orchestra"))
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `ParserError` with source offsets and caret snippets
- update CSD and Storyboard parsers to emit structured errors
- surface parser errors via CLI with file/line context

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68942e99ed2083338e8742084833c4ad