### PR TITLE
Use FSWatch on macOS and add cross-platform watch tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2d0168982d29aa5229ae4378fc8f46d1525efb467339e8366d77049e89609997",
+  "originHash" : "84199520ee4fbd079a5ae94044e00eacb6604d720baddda3ffc7dcb3d10a2c48",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
         "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-tools-support-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-tools-support-core",
+      "state" : {
+        "revision" : "e8fbc8b05a155f311b862178d92d043afb216fe3",
+        "version" : "0.7.3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
         .executable(name: "TeatroSamplerDemo", targets: ["TeatroSamplerDemo"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/swiftlang/swift-tools-support-core", from: "0.6.0")
     ],
     targets: [
         .target(
@@ -26,7 +27,8 @@ let package = Package(
             name: "RenderCLI",
             dependencies: [
                 "Teatro",
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "SwiftToolsSupport", package: "swift-tools-support-core")
             ],
             path: "Sources/CLI"
         ),


### PR DESCRIPTION
## Summary
- integrate Swift Tools Support Core for file watching on macOS
- fall back to timer-based watching on Linux
- add Linux watch-mode regression test

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6894305a463083339c4cd08bebb76ed1