### PR TITLE
feat(cli): add render target registry

### DIFF
--- a/Sources/CLI/DefaultRenderTargets.swift
+++ b/Sources/CLI/DefaultRenderTargets.swift
@@ -1,0 +1,87 @@
+import Foundation
+import ArgumentParser
+import Teatro
+
+struct HTMLTarget: RenderTargetProtocol {
+    static let name = "html"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        let result = HTMLRenderer.render(view)
+        try write(result, to: output, defaultName: "output.html")
+    }
+}
+
+struct SVGTarget: RenderTargetProtocol {
+    static let name = "svg"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        let result = SVGRenderer.render(view)
+        try write(result, to: output, defaultName: "output.svg")
+    }
+}
+
+struct PNGTarget: RenderTargetProtocol {
+    static let name = "png"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        ImageRenderer.renderToPNG(view, to: output ?? "output.png")
+    }
+}
+
+struct MarkdownTarget: RenderTargetProtocol {
+    static let name = "markdown"
+    static let aliases: [String] = ["md"]
+    static func render(view: Renderable, output: String?) throws {
+        let result = MarkdownRenderer.render(view)
+        try write(result, to: output, defaultName: "output.md")
+    }
+}
+
+struct CodexTarget: RenderTargetProtocol {
+    static let name = "codex"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        let result = CodexPreviewer.preview(view)
+        try write(result, to: output, defaultName: "output.codex")
+    }
+}
+
+struct SVGAnimatedTarget: RenderTargetProtocol {
+    static let name = "svgAnimated"
+    static let aliases: [String] = ["svg-animated"]
+    static func render(view: Renderable, output: String?) throws {
+        guard let storyboard = view as? Storyboard else {
+            throw ValidationError("Animated SVG requires a Storyboard input")
+        }
+        let result = SVGAnimator.renderAnimatedSVG(storyboard: storyboard)
+        try write(result, to: output, defaultName: "output.svg")
+    }
+}
+
+struct CsoundTarget: RenderTargetProtocol {
+    static let name = "csound"
+    static let aliases: [String] = ["csd"]
+    static func render(view: Renderable, output: String?) throws {
+        guard let score = view as? CsoundScore else {
+            throw ValidationError("Csound output requires a Csound score input")
+        }
+        CSDRenderer.renderToFile(score, to: output ?? "output.csd")
+    }
+}
+
+struct UMPTarget: RenderTargetProtocol {
+    static let name = "ump"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        guard let midiView = view as? MidiEventView else {
+            throw ValidationError("UMP output requires MIDI or UMP input")
+        }
+        let words = UMPEncoder.encodeEvents(midiView.events)
+        var data = Data()
+        for word in words {
+            var be = word.bigEndian
+            withUnsafeBytes(of: &be) { data.append(contentsOf: $0) }
+        }
+        try writeData(data, to: output, defaultName: "output.ump")
+    }
+}

--- a/Sources/CLI/RenderTargetProtocol.swift
+++ b/Sources/CLI/RenderTargetProtocol.swift
@@ -1,0 +1,34 @@
+import Foundation
+import ArgumentParser
+import Teatro
+
+public protocol RenderTargetProtocol {
+    static var name: String { get }
+    static var aliases: [String] { get }
+    static func render(view: Renderable, output: String?) throws
+}
+
+public extension RenderTargetProtocol {
+    static func write(_ string: String, to path: String?, defaultName: String) throws {
+        let isStdout = path == nil
+        if isStdout {
+            print(string)
+        } else {
+            let file = path ?? defaultName
+            try string.write(toFile: file, atomically: true, encoding: .utf8)
+            print("Wrote \(file)")
+        }
+    }
+
+    static func writeData(_ data: Data, to path: String?, defaultName: String) throws {
+        let isStdout = path == nil
+        if isStdout {
+            let hex = data.map { String(format: "%02X", $0) }.joined()
+            print(hex)
+        } else {
+            let url = URL(fileURLWithPath: path ?? defaultName)
+            try data.write(to: url)
+            print("Wrote \(url.path)")
+        }
+    }
+}

--- a/Sources/CLI/RenderTargetRegistry.swift
+++ b/Sources/CLI/RenderTargetRegistry.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public final class RenderTargetRegistry: @unchecked Sendable {
+    public static let shared = RenderTargetRegistry()
+
+    private var targets: [String: RenderTargetProtocol.Type] = [:]
+    private var uniqueTargets: [RenderTargetProtocol.Type] = []
+
+    private init() {
+        register(HTMLTarget.self)
+        register(SVGTarget.self)
+        register(PNGTarget.self)
+        register(MarkdownTarget.self)
+        register(CodexTarget.self)
+        register(SVGAnimatedTarget.self)
+        register(CsoundTarget.self)
+        register(UMPTarget.self)
+    }
+
+    public func register(_ target: RenderTargetProtocol.Type) {
+        if !uniqueTargets.contains(where: { $0.name.lowercased() == target.name.lowercased() }) {
+            uniqueTargets.append(target)
+        }
+        targets[target.name.lowercased()] = target
+        for alias in target.aliases {
+            targets[alias.lowercased()] = target
+        }
+    }
+
+    public func lookup(_ name: String) -> RenderTargetProtocol.Type? {
+        targets[name.lowercased()]
+    }
+
+    public var allTargets: [RenderTargetProtocol.Type] {
+        uniqueTargets
+    }
+
+    public var availableFormats: [String] {
+        allTargets.map { $0.name }.sorted()
+    }
+}

--- a/Tests/CLI/RenderCLICoverageTests.swift
+++ b/Tests/CLI/RenderCLICoverageTests.swift
@@ -250,7 +250,7 @@ final class RenderCLICoverageTests: XCTestCase {
         let url = tempURL("watch.txt")
         FileManager.default.createFile(atPath: url.path, contents: Data())
         defer { try? FileManager.default.removeItem(at: url) }
-        let source = cli.watchFile(path: url.path, target: .markdown, outputPath: nil)
+        let source = cli.watchFile(path: url.path, target: MarkdownTarget.self, outputPath: nil)
         XCTAssertNotNil(source)
         source?.cancel()
     }
@@ -270,7 +270,7 @@ final class RenderCLICoverageTests: XCTestCase {
             try? FileManager.default.removeItem(at: output)
         }
         let cli = RenderCLI()
-        let source = cli.watchFile(path: input.path, target: .markdown, outputPath: output.path)
+        let source = cli.watchFile(path: input.path, target: MarkdownTarget.self, outputPath: output.path)
         let exp = expectation(description: "rerender")
         DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
             try? """

--- a/Tests/CLI/RenderCLIRenderTests.swift
+++ b/Tests/CLI/RenderCLIRenderTests.swift
@@ -8,7 +8,7 @@ final class RenderCLIRenderTests: XCTestCase {
         let cli = RenderCLI()
         let view = Text("Render Test")
         let output = try captureStdout {
-            try cli.render(view: view, target: .svg, outputPath: nil)
+            try cli.render(view: view, target: SVGTarget.self, outputPath: nil)
         }
         XCTAssertTrue(output.contains("<svg"))
         XCTAssertTrue(output.contains("Render Test"))

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -249,7 +249,7 @@ final class RenderCLITests: XCTestCase {
             try? FileManager.default.removeItem(at: output)
         }
         let cli = RenderCLI()
-        let source = cli.watchFile(path: input.path, target: .markdown, outputPath: output.path)
+        let source = cli.watchFile(path: input.path, target: MarkdownTarget.self, outputPath: output.path)
         let exp = expectation(description: "rerender")
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
             try? """
@@ -281,7 +281,7 @@ final class RenderCLITests: XCTestCase {
             try? FileManager.default.removeItem(at: output)
         }
         let cli = RenderCLI()
-        let source = cli.watchFile(path: input.path, target: .markdown, outputPath: output.path)
+        let source = cli.watchFile(path: input.path, target: MarkdownTarget.self, outputPath: output.path)
         let exp = expectation(description: "rerender")
         DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) {
             try? """


### PR DESCRIPTION
## Summary
- introduce `RenderTargetProtocol` and default rendering targets
- centralize format lookup via `RenderTargetRegistry`
- update CLI parsing and watch mode to use registry-driven targets

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689445c3d5d08333b6f378e14cd60e16