### PR TITLE
feat(cli): add render target plugin registry

### DIFF
--- a/Docs/Chapters/03_RenderingBackends.md
+++ b/Docs/Chapters/03_RenderingBackends.md
@@ -142,4 +142,38 @@ swift run RenderCLI --input demo.storyboard --format svgAnimated --output anim.s
 ```
 
 ---
+### 3.7 Registering Custom Renderers
+
+Third-party packages can hook into the registry and provide additional render targets. Conform to `RenderTargetPlugin` and register it during module initialization:
+
+```swift
+import RenderCLI
+import Teatro
+
+struct MyTarget: RenderTargetProtocol {
+    static let name = "myTarget"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        try write("custom output", to: output, defaultName: "out.txt")
+    }
+}
+
+enum MyPlugin: RenderTargetPlugin {
+    static func registerTargets(in registry: RenderTargetRegistry) {
+        registry.register(MyTarget.self)
+    }
+}
+
+private let _pluginRegistration: Void = {
+    RenderTargetRegistry.register(plugin: MyPlugin.self)
+}()
+```
+
+After importing the module containing this code, the new target becomes available to the CLI:
+
+```bash
+swift run RenderCLI --format myTarget
+```
+
+---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/CLI/DefaultRenderTargets.swift
+++ b/Sources/CLI/DefaultRenderTargets.swift
@@ -85,3 +85,17 @@ struct UMPTarget: RenderTargetProtocol {
         try writeData(data, to: output, defaultName: "output.ump")
     }
 }
+
+// Plugin used to register all built-in render targets with the registry.
+struct BuiltInRenderTargetPlugin: RenderTargetPlugin {
+    static func registerTargets(in registry: RenderTargetRegistry) {
+        registry.register(HTMLTarget.self)
+        registry.register(SVGTarget.self)
+        registry.register(PNGTarget.self)
+        registry.register(MarkdownTarget.self)
+        registry.register(CodexTarget.self)
+        registry.register(SVGAnimatedTarget.self)
+        registry.register(CsoundTarget.self)
+        registry.register(UMPTarget.self)
+    }
+}

--- a/Sources/CLI/RenderTargetPlugin.swift
+++ b/Sources/CLI/RenderTargetPlugin.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// A plugin that registers custom render targets with the registry.
+public protocol RenderTargetPlugin {
+    /// Register one or more `RenderTargetProtocol` types with the provided registry.
+    static func registerTargets(in registry: RenderTargetRegistry)
+}

--- a/Sources/CLI/RenderTargetRegistry.swift
+++ b/Sources/CLI/RenderTargetRegistry.swift
@@ -7,16 +7,11 @@ public final class RenderTargetRegistry: @unchecked Sendable {
     private var uniqueTargets: [RenderTargetProtocol.Type] = []
 
     private init() {
-        register(HTMLTarget.self)
-        register(SVGTarget.self)
-        register(PNGTarget.self)
-        register(MarkdownTarget.self)
-        register(CodexTarget.self)
-        register(SVGAnimatedTarget.self)
-        register(CsoundTarget.self)
-        register(UMPTarget.self)
+        // Register built-in render targets via the default plugin
+        register(plugin: BuiltInRenderTargetPlugin.self)
     }
 
+    /// Register a single render target type.
     public func register(_ target: RenderTargetProtocol.Type) {
         if !uniqueTargets.contains(where: { $0.name.lowercased() == target.name.lowercased() }) {
             uniqueTargets.append(target)
@@ -25,6 +20,21 @@ public final class RenderTargetRegistry: @unchecked Sendable {
         for alias in target.aliases {
             targets[alias.lowercased()] = target
         }
+    }
+
+    /// Register a render target plugin which may provide multiple targets.
+    public func register(plugin: RenderTargetPlugin.Type) {
+        plugin.registerTargets(in: self)
+    }
+
+    /// Convenience static wrapper for registering a render target.
+    public static func register(_ target: RenderTargetProtocol.Type) {
+        shared.register(target)
+    }
+
+    /// Convenience static wrapper for registering a render target plugin.
+    public static func register(plugin: RenderTargetPlugin.Type) {
+        shared.register(plugin: plugin)
     }
 
     public func lookup(_ name: String) -> RenderTargetProtocol.Type? {

--- a/Tests/CLI/RenderTargetPluginTests.swift
+++ b/Tests/CLI/RenderTargetPluginTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import RenderCLI
+import Teatro
+
+// A fake render target used to verify plugin-based registration.
+private struct FakeTarget: RenderTargetProtocol {
+    static let name = "fake"
+    static let aliases: [String] = []
+    static func render(view: Renderable, output: String?) throws {
+        try write("FAKE:" + view.render(), to: output, defaultName: "fake.txt")
+    }
+}
+
+// Plugin that registers the fake target.
+private enum FakePlugin: RenderTargetPlugin {
+    static func registerTargets(in registry: RenderTargetRegistry) {
+        registry.register(FakeTarget.self)
+    }
+}
+
+final class RenderTargetPluginTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        RenderTargetRegistry.register(plugin: FakePlugin.self)
+    }
+
+    func testDynamicPluginRegistration() {
+        let target = RenderTargetRegistry.shared.lookup("fake")
+        XCTAssertNotNil(target)
+    }
+
+    func testRenderingWithPluginTarget() throws {
+        guard let target = RenderTargetRegistry.shared.lookup("fake") else {
+            XCTFail("target not registered")
+            return
+        }
+        let cli = RenderCLI()
+        let view = Text("Hello")
+        let output = try captureStdout {
+            try cli.render(view: view, target: target, outputPath: nil)
+        }
+        XCTAssertTrue(output.contains("FAKE:Hello"))
+    }
+}


### PR DESCRIPTION
## Summary
- allow third-party renderers to register dynamically via `RenderTargetPlugin`
- document custom renderer registration
- test plugin-based render target registration

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689447a705c08333b58ec600b397fab1