### PR TITLE
Replace deprecated Process.launchPath in LilyScore

### DIFF
--- a/Sources/ViewCore/LilyScore.swift
+++ b/Sources/ViewCore/LilyScore.swift
@@ -16,7 +16,7 @@ public struct LilyScore: Renderable {
         try? content.write(toFile: tempPath, atomically: true, encoding: .utf8)
 
         let task = Process()
-        task.launchPath = "/usr/bin/env"
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         task.arguments = ["lilypond", "-o", filename, tempPath]
         try? task.run()
         task.waitUntilExit()


### PR DESCRIPTION
## Summary
- use `Process.executableURL` for LilyScore rendering

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6894917299a483338f6ee384d0892d49