### PR TITLE
Refactor CsoundSampler loading

### DIFF
--- a/Sources/Audio/Samplers/CsoundSampler.swift
+++ b/Sources/Audio/Samplers/CsoundSampler.swift
@@ -22,7 +22,7 @@ public actor CsoundSampler: SampleSource {
     /// Loads a Csound orchestra file and prepares the engine.
     public func loadInstrument(_ path: String) async throws {
         await stopAll()
-        let orc = try String(contentsOfFile: path)
+        let orc = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
         let cs = csoundCreate(nil)
         csoundSetOption(cs, "-d")             // no displays
         csoundSetOption(cs, "-odac")          // output to device

--- a/task-matrix.md
+++ b/task-matrix.md
@@ -3,7 +3,7 @@
 | Feature | File(s) or Area | Action | Status | Blockers | Tags |
 |--------|-----------------|--------|--------|----------|------|
 | Replace deprecated `Process.launchPath` | Sources/ViewCore/LilyScore.swift | Switch to `executableURL` and update process launch | ⏳ | None | cli, refactor |
-| Update deprecated file-loading calls | Sources/Audio/CsoundSampler.swift; Tests/* | Use `String(contentsOf:encoding:)` across codebase | ⏳ | None | refactor, test |
+| Update deprecated file-loading calls | Sources/Audio/CsoundSampler.swift | Use `String(contentsOf:encoding:)` across codebase | ⏳ | None | refactor, test |
 | Increase renderer test coverage | Tests/RendererTests.swift and related | Add cases for HTML/Markdown and image rendering | ⏳ | Need sample fixtures | renderer, test |
 | Sync CLI docs with current flags | Docs/Chapters/04_CLIIntegration.md; Sources/CLI/RenderCLI.swift | Ensure documentation matches implemented options | ⚠️ | Manual verification | docs, cli |
 | Automate coverage report updates | COVERAGE.md; scripts | Add script/CI step to refresh coverage metrics | ❌ | Decide tooling | ci, coverage |


### PR DESCRIPTION
## Summary
- use URL-based string loading for Csound sampler
- update task matrix entry to remove tests from affected areas

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68949354e95083339932e9b2f1a5c661