### PR TITLE
Add MIDI-CI SysEx handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 
 Teatro is centered on **MIDI 2.0** for sequencing and timing. MIDI 1.0 is supported only as a fallback for legacy export.
 
+## MIDI-CI Discovery
+
+Teatro includes basic support for the MIDI Capability Inquiry (MIDI-CI) protocol.
+`MIDICI` types generate SysEx packets for discovery, profile negotiation and
+property exchange. These packets can be encoded with `UMPEncoder` and parsed
+from `UMPParser` output using `MIDICIDispatcher` to obtain strongly typed
+messages for application workflows.
+
 The long-form documentation lives under `Docs/Chapters`. Start with the timeline and progress through each chapter.
 
 ## Documentation

--- a/Sources/MIDI/MIDI.swift
+++ b/Sources/MIDI/MIDI.swift
@@ -52,3 +52,20 @@ public struct MIDIRenderer: RendererPlugin {
         renderToFile(seq, to: output ?? "output.mid")
     }
 }
+
+/// Convenience helpers for working with MIDI-CI SysEx messages.
+public enum MIDI {
+    /// Parses a MIDI-CI message from raw SysEx data.
+    /// - Parameter data: Complete SysEx byte stream including `F0` and `F7`.
+    /// - Returns: A typed `MIDICIMessage` if the packet conforms to MIDI-CI.
+    public static func parseCIMessage(from data: Data) -> MIDICIMessage? {
+        MIDICI.parse(sysEx: data)
+    }
+
+    /// Serializes a MIDI-CI message into a SysEx byte stream.
+    /// - Parameter message: The message to encode.
+    /// - Returns: Raw SysEx data including start/end markers.
+    public static func sysEx(for message: MIDICIMessage) -> Data {
+        MIDICI.serialize(message)
+    }
+}

--- a/Sources/MIDI/MIDICI.swift
+++ b/Sources/MIDI/MIDICI.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// MIDI Capability Inquiry message container.
+public enum MIDICIMessage: Equatable {
+    case discovery(MIDICIDiscovery)
+    case profile(MIDICIProfileNegotiation)
+    case property(MIDICIPropertyExchange)
+}
+
+/// MIDI-CI Discovery message.
+public struct MIDICIDiscovery: Equatable {
+    public let deviceID: UInt8
+    public let payload: Data
+
+    public init(deviceID: UInt8, payload: Data = Data()) {
+        self.deviceID = deviceID
+        self.payload = payload
+    }
+
+    /// Serializes the message to a SysEx byte stream.
+    public func sysex() -> Data {
+        var bytes: [UInt8] = [0xF0, 0x7E, deviceID, 0x0D, 0x70]
+        bytes.append(contentsOf: payload)
+        bytes.append(0xF7)
+        return Data(bytes)
+    }
+}
+
+/// MIDI-CI Profile negotiation message.
+public struct MIDICIProfileNegotiation: Equatable {
+    public let deviceID: UInt8
+    public let payload: Data
+
+    public init(deviceID: UInt8, payload: Data = Data()) {
+        self.deviceID = deviceID
+        self.payload = payload
+    }
+
+    public func sysex() -> Data {
+        var bytes: [UInt8] = [0xF0, 0x7E, deviceID, 0x0D, 0x72]
+        bytes.append(contentsOf: payload)
+        bytes.append(0xF7)
+        return Data(bytes)
+    }
+}
+
+/// MIDI-CI Property exchange message.
+public struct MIDICIPropertyExchange: Equatable {
+    public let deviceID: UInt8
+    public let property: String
+    public let value: Data?
+
+    public init(deviceID: UInt8, property: String, value: Data? = nil) {
+        self.deviceID = deviceID
+        self.property = property
+        self.value = value
+    }
+
+    public func sysex() -> Data {
+        var bytes: [UInt8] = [0xF0, 0x7E, deviceID, 0x0D, 0x78]
+        bytes.append(contentsOf: property.utf8)
+        if let v = value { bytes.append(contentsOf: v) }
+        bytes.append(0xF7)
+        return Data(bytes)
+    }
+}
+
+/// Parsing helpers for MIDI-CI messages.
+public enum MIDICI {
+    /// Parses a SysEx byte stream into a `MIDICIMessage`.
+    /// The data must include the `F0`/`F7` markers.
+    public static func parse(sysEx data: Data) -> MIDICIMessage? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 6,
+              bytes.first == 0xF0,
+              bytes.last == 0xF7,
+              bytes[3] == 0x0D else { return nil }
+        let deviceID = bytes[2]
+        let subID2 = bytes[4]
+        let payload = Data(bytes[5..<(bytes.count - 1)])
+        switch subID2 {
+        case 0x70:
+            return .discovery(MIDICIDiscovery(deviceID: deviceID, payload: payload))
+        case 0x72:
+            return .profile(MIDICIProfileNegotiation(deviceID: deviceID, payload: payload))
+        case 0x78:
+            let prop = String(data: payload, encoding: .utf8) ?? ""
+            return .property(MIDICIPropertyExchange(deviceID: deviceID, property: prop, value: nil))
+        default:
+            return nil
+        }
+    }
+
+    /// Serializes a `MIDICIMessage` into SysEx data.
+    public static func serialize(_ message: MIDICIMessage) -> Data {
+        switch message {
+        case .discovery(let d): return d.sysex()
+        case .profile(let p): return p.sysex()
+        case .property(let p): return p.sysex()
+        }
+    }
+}

--- a/Sources/MIDI/MIDICIDispatcher.swift
+++ b/Sources/MIDI/MIDICIDispatcher.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Routes SysEx events through the MIDI-CI parser.
+public struct MIDICIDispatcher {
+    /// Attempts to interpret a parsed MIDI event as a MIDI-CI message.
+    /// - Parameter event: A `MidiEventProtocol` value, typically produced by `UMPParser`.
+    /// - Returns: A `MIDICIMessage` if the event is a valid MIDI-CI SysEx packet.
+    public static func dispatch(event: any MidiEventProtocol) -> MIDICIMessage? {
+        guard event.type == .sysEx, let raw = event.rawData else { return nil }
+        let bytes = [UInt8](raw)
+        guard let start = bytes.firstIndex(of: 0xF0),
+              let end = bytes.lastIndex(of: 0xF7),
+              start < end else { return nil }
+        let payload = Data(bytes[start...end])
+        return MIDICI.parse(sysEx: payload)
+    }
+}

--- a/Tests/MIDITests/MIDICITests.swift
+++ b/Tests/MIDITests/MIDICITests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Teatro
+
+final class MIDICITests: XCTestCase {
+    func testDiscoveryRoundTrip() throws {
+        let discovery = MIDICIDiscovery(deviceID: 0x01)
+        let sysEx = discovery.sysex()
+        let event = SysExEvent(timestamp: 0, data: sysEx, group: 0)
+        let words = UMPEncoder.encodeEvent(event, defaultGroup: 0)
+        var data = Data()
+        for word in words {
+            var be = word.bigEndian
+            withUnsafeBytes(of: &be) { data.append(contentsOf: $0) }
+        }
+        let parsed = try UMPParser.parse(data: data)
+        guard let parsedEvent = parsed.first else {
+            return XCTFail("Expected event")
+        }
+        guard let msg = MIDICIDispatcher.dispatch(event: parsedEvent) else {
+            return XCTFail("Expected MIDI-CI message")
+        }
+        guard case .discovery(let decoded) = msg else {
+            return XCTFail("Expected discovery message")
+        }
+        XCTAssertEqual(decoded.deviceID, discovery.deviceID)
+    }
+
+    func testMalformedPacketIgnored() throws {
+        let malformed = Data([0xF0, 0x7E, 0x01, 0x0D, 0x70]) // missing terminator
+        let event = SysExEvent(timestamp: 0, data: malformed, group: 0)
+        let words = UMPEncoder.encodeEvent(event, defaultGroup: 0)
+        var data = Data()
+        for word in words {
+            var be = word.bigEndian
+            withUnsafeBytes(of: &be) { data.append(contentsOf: $0) }
+        }
+        let parsed = try UMPParser.parse(data: data)
+        guard let parsedEvent = parsed.first else {
+            return XCTFail("Expected event")
+        }
+        let msg = MIDICIDispatcher.dispatch(event: parsedEvent)
+        XCTAssertNil(msg)
+    }
+
+    func testPropertyExchangeRoundTrip() throws {
+        let property = MIDICIPropertyExchange(deviceID: 0x02, property: "")
+        let sysEx = property.sysex()
+        let event = SysExEvent(timestamp: 0, data: sysEx, group: 0)
+        let words = UMPEncoder.encodeEvent(event, defaultGroup: 0)
+        var data = Data()
+        for word in words {
+            var be = word.bigEndian
+            withUnsafeBytes(of: &be) { data.append(contentsOf: $0) }
+        }
+        let parsed = try UMPParser.parse(data: data)
+        guard let parsedEvent = parsed.first else {
+            return XCTFail("Expected event")
+        }
+        guard let msg = MIDICIDispatcher.dispatch(event: parsedEvent) else {
+            return XCTFail("Expected MIDI-CI message")
+        }
+        guard case .property(let decoded) = msg else {
+            return XCTFail("Expected property exchange message")
+        }
+        XCTAssertEqual(decoded.deviceID, property.deviceID)
+    }
+}


### PR DESCRIPTION
## Summary
- add MIDI-CI structs and helpers for discovery, profile negotiation and property exchange
- support MIDI-CI SysEx packets in MIDI helper utilities and UMP encoding
- document MIDI-CI discovery workflow and provide dispatcher for incoming messages

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68949fe66be08333ac95cd6e523657d2