### PR TITLE
Add spec UMP note management tests and encoder fixes

### DIFF
--- a/Sources/MIDI/UMPEncoder.swift
+++ b/Sources/MIDI/UMPEncoder.swift
@@ -109,16 +109,18 @@ public struct UMPEncoder {
             let groupBits = UInt32((event.group ?? defaultGroup) & 0xF) << 24
             let channelBits = UInt32((event.channel ?? 0) & 0xF) << 16
             let noteBits = UInt32((event.noteNumber ?? 0) & 0x7F) << 8
-            let word1 = messageType | groupBits | (0x2 << 20) | channelBits | noteBits
-            return [word1, p.pitch]
+            let word1 = messageType | groupBits | (0x1 << 20) | channelBits | noteBits
+            let word2 = (0x2 << 28) | (p.pitch & 0x0FFFFFFF)
+            return [word1, word2]
         case .pitchRelease:
             guard let _ = event as? PitchReleaseEvent else { return [] }
             let messageType: UInt32 = 0x4 << 28
             let groupBits = UInt32((event.group ?? defaultGroup) & 0xF) << 24
             let channelBits = UInt32((event.channel ?? 0) & 0xF) << 16
             let noteBits = UInt32((event.noteNumber ?? 0) & 0x7F) << 8
-            let word1 = messageType | groupBits | (0x3 << 20) | channelBits | noteBits
-            return [word1, 0]
+            let word1 = messageType | groupBits | (0x1 << 20) | channelBits | noteBits
+            let word2: UInt32 = 0x3 << 28
+            return [word1, word2]
         case .noteAttribute:
             guard let attr = event as? NoteAttributeEvent else { return [] }
             let messageType: UInt32 = 0x4 << 28

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -134,7 +134,7 @@ public struct UMPParser {
                 let subtype = UInt8((word2 >> 28) & 0xF)
                 switch subtype {
                 case 0x0:
-                    let velocity = UInt32((word2 >> 16) & 0xFFFF)
+                    let velocity = UInt32((word2 >> 16) & 0xFFFF) << 16
                     let attributeData = UInt16(word2 & 0xFFFF)
                     return NoteEndEvent(
                         timestamp: 0,

--- a/Tests/MIDITests/MIDI2Tests.swift
+++ b/Tests/MIDITests/MIDI2Tests.swift
@@ -68,6 +68,91 @@ final class MIDI2Tests: XCTestCase {
         }
         XCTAssertEqual(event.value, 0x00000001)
     }
+
+    // MARK: - Spec fixture round-trips
+
+    /// Helper converting 32-bit words into raw bytes
+    private func bytes(from words: [UInt32]) -> [UInt8] {
+        var out: [UInt8] = []
+        for w in words {
+            out.append(UInt8((w >> 24) & 0xFF))
+            out.append(UInt8((w >> 16) & 0xFF))
+            out.append(UInt8((w >> 8) & 0xFF))
+            out.append(UInt8(w & 0xFF))
+        }
+        return out
+    }
+
+    func testRoundTripNoteOnWithAttributeFromSpec() throws {
+        let words: [UInt32] = [0x40903C02, 0x12345678]
+        let events = try UMPParser.parse(data: Data(bytes(from: words)))
+        guard let event = events.first as? NoteOnWithAttributeEvent else {
+            return XCTFail("Expected NoteOnWithAttributeEvent")
+        }
+        XCTAssertEqual(event.noteNumber, 0x3C)
+        XCTAssertEqual(event.attributeType, .profileSpecific)
+        XCTAssertEqual(event.attributeData, 0x5678)
+        XCTAssertEqual(event.velocity, 0x12340000)
+        let encoded = UMPEncoder.encodeEvents(events)
+        XCTAssertEqual(encoded, words)
+    }
+
+    func testRoundTripPitchClampReleaseFromSpec() throws {
+        let words: [UInt32] = [
+            0x40103C00, 0x21234567,
+            0x40103C00, 0x30000000
+        ]
+        let events = try UMPParser.parse(data: Data(bytes(from: words)))
+        XCTAssertEqual(events.count, 2)
+        guard let clamp = events.first as? PitchClampEvent,
+              let release = events.last as? PitchReleaseEvent else {
+            return XCTFail("Expected PitchClampEvent then PitchReleaseEvent")
+        }
+        XCTAssertEqual(clamp.noteNumber, 0x3C)
+        XCTAssertEqual(clamp.pitch, 0x01234567)
+        XCTAssertEqual(release.noteNumber, 0x3C)
+        let encoded = UMPEncoder.encodeEvents(events)
+        XCTAssertEqual(encoded, words)
+    }
+
+    func testRoundTripNoteEndFromSpec() throws {
+        let words: [UInt32] = [0x40103C00, 0x01234567]
+        let events = try UMPParser.parse(data: Data(bytes(from: words)))
+        guard let end = events.first as? NoteEndEvent else {
+            return XCTFail("Expected NoteEndEvent")
+        }
+        XCTAssertEqual(end.noteNumber, 0x3C)
+        XCTAssertEqual(end.velocity, 0x01230000)
+        XCTAssertEqual(end.attributeData, 0x4567)
+        let encoded = UMPEncoder.encodeEvents(events)
+        XCTAssertEqual(encoded, words)
+    }
+
+    // MARK: - Negative cases
+
+    func testMalformedNoteManagementMissingWordThrows() {
+        let bytes: [UInt8] = [0x40, 0x10, 0x3C, 0x00]
+        XCTAssertThrowsError(try UMPParser.parse(data: Data(bytes))) { error in
+            guard case UMPParserError.truncated = error else {
+                return XCTFail("Expected truncated error")
+            }
+        }
+    }
+
+    func testTruncatedNoteOnWithAttributeThrows() {
+        let bytes: [UInt8] = [0x40, 0x90, 0x3C, 0x02]
+        XCTAssertThrowsError(try UMPParser.parse(data: Data(bytes))) { error in
+            guard case UMPParserError.truncated = error else {
+                return XCTFail("Expected truncated error")
+            }
+        }
+    }
+
+    func testInvalidNoteManagementSubtypeReturnsUnknown() throws {
+        let words: [UInt32] = [0x40103C00, 0x10000000]
+        let events = try UMPParser.parse(data: Data(bytes(from: words)))
+        XCTAssertTrue(events.first is UnknownEvent)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add spec-based UMP fixtures for note-on with attribute, pitch clamp/release, and note end
- fix UMPEncoder and parser for note management status and velocity scaling
- cover malformed UMP sequences with negative tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_6894cbbe22588333bf2bbef2739a4eb3