### PR TITLE
feat: add MIDI2 dependency and facade skeleton

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "84199520ee4fbd079a5ae94044e00eacb6604d720baddda3ffc7dcb3d10a2c48",
+  "originHash" : "83cf2fd4125154233bc7a10b95e76999cb577a18a159340156fb9a28518270f0",
   "pins" : [
+    {
+      "identity" : "midi2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Fountain-Coach/midi2",
+      "state" : {
+        "revision" : "91812a2a267a7d4248ce22303ff653b39ddae260",
+        "version" : "0.2.0"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,15 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/swiftlang/swift-tools-support-core", from: "0.6.0")
+        .package(url: "https://github.com/swiftlang/swift-tools-support-core", from: "0.6.0"),
+        .package(url: "https://github.com/Fountain-Coach/midi2", from: "0.2.0")
     ],
     targets: [
         .target(
             name: "Teatro",
-            dependencies: ["CCsound", "CFluidSynth"],
+            dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2")],
             path: "Sources",
-            exclude: ["CLI", "TeatroSamplerDemo", "CCsound", "CFluidSynth"]
+            exclude: ["CLI", "TeatroSamplerDemo", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md"]
         ),
         .executableTarget(
             name: "RenderCLI",

--- a/Sources/MIDI/FlexEnvelope.swift
+++ b/Sources/MIDI/FlexEnvelope.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Minimal representation of a Flex envelope used for MIDI 2.0 messaging.
+/// The structure mirrors the fields outlined in the Teatro Codex plan and
+/// will be extended to map to `Fountain-Coach/midi2` types in follow-up work.
+public struct FlexEnvelope {
+    /// Envelope version.
+    public var v: Int
+    /// Timestamp in microseconds.
+    public var ts: UInt64
+    /// Correlation identifier.
+    public var corr: String
+    /// Intent string describing the semantic meaning of `body`.
+    public var intent: String
+    /// Arbitrary JSON body carried by the envelope.
+    public var body: [String: Any]
+
+    public init(v: Int, ts: UInt64, corr: String, intent: String, body: [String: Any]) {
+        self.v = v
+        self.ts = ts
+        self.corr = corr
+        self.intent = intent
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/Sources/MIDI/UMPEvent.swift
+++ b/Sources/MIDI/UMPEvent.swift
@@ -1,0 +1,16 @@
+import Foundation
+import MIDI2
+
+/// Unified representation of Universal MIDI Packets used by Teatro.
+/// This facade wraps packet types from `Fountain-Coach/midi2` and provides
+/// a stable surface for future integration.
+public enum UMPEvent {
+    case channelVoice
+    case utility
+    case systemExclusive7
+    case systemExclusive8
+    case flexEnvelope(FlexEnvelope)
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+


### PR DESCRIPTION
## Summary
- add `Fountain-Coach/midi2` package dependency and exclude plan doc from build
- introduce placeholder `FlexEnvelope` and `UMPEvent` types for future MIDI2 facade

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689e205cfba48333aa5e6f305712b7d3