### PR TITLE
Implement MIDI2 facade and Flex envelope round-trip tests

### DIFF
--- a/Sources/MIDI/AnyCodable.swift
+++ b/Sources/MIDI/AnyCodable.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A type-erased `Codable` value used to encode and decode arbitrary JSON.
+public struct AnyCodable: Codable {
+    public let value: Any
+
+    public init(_ value: Any) {
+        self.value = value
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let bool = try? container.decode(Bool.self) {
+            value = bool
+        } else if let int = try? container.decode(Int.self) {
+            value = int
+        } else if let double = try? container.decode(Double.self) {
+            value = double
+        } else if let string = try? container.decode(String.self) {
+            value = string
+        } else if container.decodeNil() {
+            value = ()
+        } else if var unkeyed = try? decoder.unkeyedContainer() {
+            var array: [Any] = []
+            while !unkeyed.isAtEnd {
+                let decoded = try unkeyed.decode(AnyCodable.self)
+                array.append(decoded.value)
+            }
+            value = array
+        } else if let keyed = try? decoder.container(keyedBy: CodingKeys.self) {
+            var dict: [String: Any] = [:]
+            for key in keyed.allKeys {
+                let decoded = try keyed.decode(AnyCodable.self, forKey: key)
+                dict[key.stringValue] = decoded.value
+            }
+            value = dict
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch value {
+        case let bool as Bool:
+            try container.encode(bool)
+        case let int as Int:
+            try container.encode(int)
+        case let double as Double:
+            try container.encode(double)
+        case let string as String:
+            try container.encode(string)
+        case let array as [Any]:
+            var unkeyed = encoder.unkeyedContainer()
+            for element in array {
+                let value = AnyCodable(element)
+                try unkeyed.encode(value)
+            }
+        case let dict as [String: Any]:
+            var keyed = encoder.container(keyedBy: CodingKeys.self)
+            for (key, val) in dict {
+                try keyed.encode(AnyCodable(val), forKey: CodingKeys(stringValue: key)!)
+            }
+        default:
+            try container.encodeNil()
+        }
+    }
+
+    private struct CodingKeys: CodingKey {
+        var stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        var intValue: Int? { nil }
+        init?(intValue: Int) { return nil }
+    }
+}

--- a/Sources/MIDI/FlexEnvelope.swift
+++ b/Sources/MIDI/FlexEnvelope.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// Minimal representation of a Flex envelope used for MIDI 2.0 messaging.
 /// The structure mirrors the fields outlined in the Teatro Codex plan and
-/// will be extended to map to `Fountain-Coach/midi2` types in follow-up work.
-public struct FlexEnvelope {
+/// is `Codable` so envelopes can be round-tripped in tests and tools.
+public struct FlexEnvelope: Codable {
     /// Envelope version.
     public var v: Int
     /// Timestamp in microseconds.
@@ -13,9 +13,9 @@ public struct FlexEnvelope {
     /// Intent string describing the semantic meaning of `body`.
     public var intent: String
     /// Arbitrary JSON body carried by the envelope.
-    public var body: [String: Any]
+    public var body: [String: AnyCodable]
 
-    public init(v: Int, ts: UInt64, corr: String, intent: String, body: [String: Any]) {
+    public init(v: Int, ts: UInt64, corr: String, intent: String, body: [String: AnyCodable]) {
         self.v = v
         self.ts = ts
         self.corr = corr

--- a/Sources/MIDI/UMPEvent.swift
+++ b/Sources/MIDI/UMPEvent.swift
@@ -1,15 +1,59 @@
 import Foundation
 import MIDI2
 
+// Refs: teatro-root
+
 /// Unified representation of Universal MIDI Packets used by Teatro.
 /// This facade wraps packet types from `Fountain-Coach/midi2` and provides
 /// a stable surface for future integration.
 public enum UMPEvent {
-    case channelVoice
-    case utility
-    case systemExclusive7
-    case systemExclusive8
+    case channelVoice(Midi2ChannelVoiceBody)
+    case utility(UtilityBody)
+    case systemExclusive7(SysEx7Packet)
+    case systemExclusive8(UmpPacket128)
     case flexEnvelope(FlexEnvelope)
+
+    /// Creates a `UMPEvent` by parsing raw 32-bit words.
+    /// Returns `nil` if the words do not encode a recognised packet type.
+    public init?(words: [UInt32]) {
+        guard let first = words.first else { return nil }
+        let mt = UInt8((first >> 28) & 0xF)
+        switch mt {
+        case 0x0:
+            let packet = UmpPacket32(word: first)
+            guard let body = UtilityBody(ump: packet) else { return nil }
+            self = .utility(body)
+        case 0x4:
+            guard let packet = UmpPacket64(words: words),
+                  let body = Midi2ChannelVoiceBody(ump: packet) else { return nil }
+            self = .channelVoice(body)
+        case 0x5:
+            guard let pkt = UmpPacket64(words: words),
+                  let packet = SysEx7Packet(ump: pkt) else { return nil }
+            self = .systemExclusive7(packet)
+        case 0x6:
+            guard let packet = UmpPacket128(words: words) else { return nil }
+            self = .systemExclusive8(packet)
+        default:
+            return nil
+        }
+    }
+
+    /// Raw 32-bit words backing the event.
+    public var words: [UInt32] {
+        switch self {
+        case .utility(let body):
+            return [body.ump().word]
+        case .channelVoice(let body):
+            return body.ump().words
+        case .systemExclusive7(let packet):
+            return packet.ump.words
+        case .systemExclusive8(let packet):
+            return packet.words
+        case .flexEnvelope:
+            return []
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/MIDITests/FlexEnvelopeTests.swift
+++ b/Tests/MIDITests/FlexEnvelopeTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Teatro
+
+final class FlexEnvelopeTests: XCTestCase {
+    func testJSONRoundTrip() throws {
+        let json = """
+        {"v":1,"ts":123,"corr":"abc","intent":"test","body":{"foo":"bar","num":5}}
+        """.data(using: .utf8)!
+        let env = try JSONDecoder().decode(FlexEnvelope.self, from: json)
+        XCTAssertEqual(env.v, 1)
+        XCTAssertEqual(env.ts, 123)
+        XCTAssertEqual(env.corr, "abc")
+        XCTAssertEqual(env.intent, "test")
+        XCTAssertEqual(env.body["foo"]?.value as? String, "bar")
+        XCTAssertEqual(env.body["num"]?.value as? Int, 5)
+        let encoded = try JSONEncoder().encode(env)
+        let decoded = try JSONDecoder().decode(FlexEnvelope.self, from: encoded)
+        XCTAssertEqual(decoded.corr, "abc")
+        XCTAssertEqual(decoded.body["foo"]?.value as? String, "bar")
+    }
+}

--- a/Tests/MIDITests/UMPEventFacadeTests.swift
+++ b/Tests/MIDITests/UMPEventFacadeTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import MIDI2
+@testable import Teatro
+
+final class UMPEventFacadeTests: XCTestCase {
+    func testNoteOnRoundTrip() {
+        let note = Midi2NoteOn(
+            group: Uint4(0)!,
+            channel: Uint4(1)!,
+            note: Uint7(60)!,
+            velocity: 0x1234
+        )
+        let packet = note.ump()
+        guard let event = UMPEvent(words: packet.words) else {
+            XCTFail("Failed to parse packet")
+            return
+        }
+        guard case .channelVoice(let body) = event else {
+            XCTFail("Expected channelVoice event")
+            return
+        }
+        XCTAssertEqual(body, Midi2ChannelVoiceBody(ump: packet)!)
+        XCTAssertEqual(event.words, packet.words)
+    }
+}


### PR DESCRIPTION
## Summary
- implement UMPEvent facade over Fountain-Coach/midi2 types
- make FlexEnvelope codable via AnyCodable helper
- add round-trip tests for UMPEvent and FlexEnvelope

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689e23dec7c483338f6d6bf90207e010