### PR TITLE
feat: add Apple audio engine sink

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,10 @@ let package = Package(
             name: "Teatro",
             dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2")],
             path: "Sources",
-            exclude: ["CLI", "TeatroSamplerDemo", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md"]
+            exclude: ["CLI", "TeatroSamplerDemo", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md"],
+            linkerSettings: [
+                .linkedFramework("AVFoundation", .when(platforms: [.macOS]))
+            ]
         ),
         .executableTarget(
             name: "RenderCLI",

--- a/Sources/Audio/MIDIAudioSink.swift
+++ b/Sources/Audio/MIDIAudioSink.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Minimal protocol for audio sinks that respond to MIDI 1.0-style events.
+public protocol MIDIAudioSink {
+    /// Trigger a note-on event.
+    func noteOn(note: UInt8, vel: UInt8, ch: UInt8)
+    /// Trigger a note-off event.
+    func noteOff(note: UInt8, ch: UInt8)
+    /// Send a controller change event.
+    func controlChange(cc: UInt8, value: UInt8, ch: UInt8)
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Audio/TeatroAudioEngine.swift
+++ b/Sources/Audio/TeatroAudioEngine.swift
@@ -1,0 +1,44 @@
+#if canImport(AVFoundation)
+import AVFoundation
+
+/// Apple-specific audio engine backed by `AVAudioEngine` and `AVAudioUnitSampler`.
+/// Loads a default SoundFont if available and exposes MIDI 1.0 style methods
+/// via `MIDIAudioSink`.
+public final class TeatroAudioEngine: MIDIAudioSink {
+    private let engine = AVAudioEngine()
+    private let sampler = AVAudioUnitSampler()
+
+    public init() throws {
+        engine.attach(sampler)
+        engine.connect(sampler, to: engine.mainMixerNode, format: nil)
+        try engine.start()
+        let defaultSF2 = "/Library/Sounds/GeneralUser.sf2"
+        if FileManager.default.fileExists(atPath: defaultSF2) {
+            let url = URL(fileURLWithPath: defaultSF2)
+            try? sampler.loadSoundBankInstrument(at: url, program: 0, bankMSB: 0x79, bankLSB: 0x00)
+        }
+    }
+
+    public func noteOn(note: UInt8, vel: UInt8, ch: UInt8) {
+        sampler.startNote(MIDINoteNumber(note), withVelocity: MIDIVelocity(vel), onChannel: ch)
+    }
+
+    public func noteOff(note: UInt8, ch: UInt8) {
+        sampler.stopNote(MIDINoteNumber(note), onChannel: ch)
+    }
+
+    public func controlChange(cc: UInt8, value: UInt8, ch: UInt8) {
+        sampler.sendController(MIDIController(cc), withValue: value, onChannel: ch)
+    }
+}
+#else
+/// Fallback stub used on non-Apple platforms.
+public final class TeatroAudioEngine: MIDIAudioSink {
+    public init() throws {}
+    public func noteOn(note: UInt8, vel: UInt8, ch: UInt8) {}
+    public func noteOff(note: UInt8, ch: UInt8) {}
+    public func controlChange(cc: UInt8, value: UInt8, ch: UInt8) {}
+}
+#endif
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- introduce `MIDIAudioSink` protocol
- add Apple-specific `TeatroAudioEngine` backed by `AVAudioUnitSampler`
- bridge UMP data to `MIDIAudioSink` via `MIDI1Bridge`
- link AVFoundation on macOS and test audio bridge

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*
- `swift test --filter testBridgeToAudioSink`


------
https://chatgpt.com/codex/tasks/task_b_689e2d31b9d483338cb03caf8bbfe1ba