### PR TITLE
Add FluidSynth sink and playback CLI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
             targets: ["Teatro"]
         ),
         .executable(name: "RenderCLI", targets: ["RenderCLI"]),
-        .executable(name: "TeatroSamplerDemo", targets: ["TeatroSamplerDemo"])
+        .executable(name: "TeatroSamplerDemo", targets: ["TeatroSamplerDemo"]),
+        .executable(name: "teatro-play", targets: ["TeatroPlay"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
@@ -22,7 +23,7 @@ let package = Package(
             name: "Teatro",
             dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2")],
             path: "Sources",
-            exclude: ["CLI", "TeatroSamplerDemo", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md"],
+            exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md"],
             linkerSettings: [
                 .linkedFramework("AVFoundation", .when(platforms: [.macOS]))
             ]
@@ -44,6 +45,14 @@ let package = Package(
                 .copy("../../assets/sine.orc"),
                 .copy("../../assets/example.sf2")
             ]
+        ),
+        .executableTarget(
+            name: "TeatroPlay",
+            dependencies: [
+                "Teatro",
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
+            path: "Sources/TeatroPlay"
         ),
         .testTarget(
             name: "TeatroTests",

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ The command above reads a UMP file, translates it to MIDI 1.0 bytes, and writes
 the result to standard output (or the file specified with `--output`).
 `MIDI1Bridge.midi1ToUMP(_:)` performs the inverse conversion when needed.
 
+### Command-line Playback
+
+Pipe bridged MIDI data into the `teatro-play` utility to hear it through
+FluidSynth on Linux or the Apple sampler on macOS:
+
+```bash
+swift run RenderCLI song.ump --midi1-bridge | \
+    swift run teatro-play --from-stdin --sink fluidsynth --sf2 ./GeneralUser.sf2
+```
+
 The long-form documentation lives under `Docs/Chapters`. Start with the timeline and progress through each chapter.
 
 ## Documentation

--- a/Sources/Audio/FluidSynthSink.swift
+++ b/Sources/Audio/FluidSynthSink.swift
@@ -1,0 +1,56 @@
+import Foundation
+import CFluidSynth
+
+// Refs: teatro-root
+
+/// Audio sink based on the FluidSynth library. Acts as the default
+/// backend on Linux systems and plays SoundFont (SF2) files.
+public final class FluidSynthSink: MIDIAudioSink {
+    private var settings: OpaquePointer?
+    private var synth: OpaquePointer?
+    private var driver: OpaquePointer?
+
+    /// Create a sink and load the given SoundFont file.
+    /// - Parameter sf2Path: Path to an SF2 sound font.
+    public init(sf2Path: String) throws {
+        let set = new_fluid_settings()
+        #if os(macOS)
+        fluid_settings_setstr(set, "audio.driver", "coreaudio")
+        #else
+        fluid_settings_setstr(set, "audio.driver", "pulseaudio")
+        #endif
+        let syn = new_fluid_synth(set)
+        if fluid_synth_sfload(syn, sf2Path, 1) == FLUID_FAILED {
+            delete_fluid_synth(syn)
+            delete_fluid_settings(set)
+            throw NSError(domain: "FluidSynthSink", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Failed to load \(sf2Path)"])
+        }
+        let drv = new_fluid_audio_driver(set, syn)
+        self.settings = set
+        self.synth = syn
+        self.driver = drv
+    }
+
+    deinit {
+        if let d = driver { delete_fluid_audio_driver(d) }
+        if let s = synth { delete_fluid_synth(s) }
+        if let set = settings { delete_fluid_settings(set) }
+    }
+
+    public func noteOn(note: UInt8, vel: UInt8, ch: UInt8) {
+        guard let syn = synth else { return }
+        fluid_synth_noteon(syn, Int32(ch), Int32(note), Int32(vel))
+    }
+
+    public func noteOff(note: UInt8, ch: UInt8) {
+        guard let syn = synth else { return }
+        fluid_synth_noteoff(syn, Int32(ch), Int32(note))
+    }
+
+    public func controlChange(cc: UInt8, value: UInt8, ch: UInt8) {
+        // Control changes are currently ignored in this stub
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/Audio/SfizzSink.swift
+++ b/Sources/Audio/SfizzSink.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+// Refs: teatro-root
+
+/// Placeholder audio sink for the sfizz backend. Currently acts as a no-op
+/// implementation to allow callers to select an SFZ sink without failing to
+/// build when sfizz is unavailable.
+public final class SfizzSink: MIDIAudioSink {
+    public init(sfzPath: String) {}
+    public func noteOn(note: UInt8, vel: UInt8, ch: UInt8) {}
+    public func noteOff(note: UInt8, ch: UInt8) {}
+    public func controlChange(cc: UInt8, value: UInt8, ch: UInt8) {}
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/TeatroPlay/main.swift
+++ b/Sources/TeatroPlay/main.swift
@@ -1,0 +1,67 @@
+import Foundation
+import ArgumentParser
+import Teatro
+
+// Refs: teatro-root
+
+@main
+struct TeatroPlay: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Play UMP or MIDI1 data through an audio sink"
+    )
+
+    @Flag(name: .long, help: "Read input from stdin")
+    var fromStdin: Bool = false
+
+    @Option(name: .long, help: "Input file path")
+    var input: String?
+
+    @Option(name: .long, help: "Audio sink to use (fluidsynth or sfizz)")
+    var sink: String = "fluidsynth"
+
+    @Option(name: .long, help: "Path to an SF2 SoundFont for FluidSynth")
+    var sf2: String?
+
+    @Option(name: .long, help: "Path to an SFZ preset for Sfizz")
+    var sfz: String?
+
+    func run() throws {
+        let data: Data
+        if let path = input {
+            data = try Data(contentsOf: URL(fileURLWithPath: path))
+        } else if fromStdin {
+            data = FileHandle.standardInput.readDataToEndOfFile()
+        } else {
+            throw ValidationError("Provide --input or --from-stdin")
+        }
+
+        let audioSink: MIDIAudioSink
+        switch sink.lowercased() {
+        case "fluidsynth":
+            let font = sf2 ?? "assets/example.sf2"
+            audioSink = try FluidSynthSink(sf2Path: font)
+        case "sfizz":
+            let preset = sfz ?? ""
+            audioSink = SfizzSink(sfzPath: preset)
+        default:
+            throw ValidationError("Unsupported sink \(sink)")
+        }
+
+        if data.count % 4 == 0 {
+            try MIDI1Bridge.umpToMIDI1(data, sink: audioSink)
+        } else {
+            let words = MIDI1Bridge.midi1ToUMP(data)
+            var umpData = Data()
+            for w in words {
+                let be = w.bigEndian
+                umpData.append(UInt8(truncatingIfNeeded: be >> 24))
+                umpData.append(UInt8(truncatingIfNeeded: be >> 16))
+                umpData.append(UInt8(truncatingIfNeeded: be >> 8))
+                umpData.append(UInt8(truncatingIfNeeded: be))
+            }
+            try MIDI1Bridge.umpToMIDI1(umpData, sink: audioSink)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/SamplerTests/FluidSynthSinkTests.swift
+++ b/Tests/SamplerTests/FluidSynthSinkTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import Teatro
+
+final class FluidSynthSinkTests: XCTestCase {
+    func testSinkPlaysNote() throws {
+        let path = FileManager.default.currentDirectoryPath + "/assets/example.sf2"
+        let sink = try FluidSynthSink(sf2Path: path)
+        sink.noteOn(note: 60, vel: 100, ch: 0)
+        sink.noteOff(note: 60, ch: 0)
+        sink.controlChange(cc: 1, value: 2, ch: 0)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement FluidSynth-based `MIDIAudioSink` and placeholder `SfizzSink`
- add `teatro-play` executable for piping UMP or MIDI1 streams into audio sinks
- document CLI playback and wire new target into Package manifest

## Testing
- `swift test` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_b_689e308badf88333b6a921dc4514f74b