### PR TITLE
chore: clean up legacy MIDI types

### DIFF
--- a/Sources/Audio/MIDI2NoteEvent.swift
+++ b/Sources/Audio/MIDI2NoteEvent.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Rich MIDI 2.0 event representation used by compatibility helpers.
+@available(*, deprecated, message: "Use types from the MIDI2 module directly")
 public struct MIDI2NoteEvent: Sendable, Equatable {
     public var channel: Int
     public var note: Int

--- a/Sources/MIDI/MIDI2.swift
+++ b/Sources/MIDI/MIDI2.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Supported per-note attribute identifiers.
+@available(*, deprecated, message: "Use `NoteAttributeType` from the MIDI2 module")
 public enum MIDI2NoteAttribute: UInt8, CaseIterable, Sendable {
     /// No attribute data.
     case none = 0x00
@@ -13,6 +14,7 @@ public enum MIDI2NoteAttribute: UInt8, CaseIterable, Sendable {
 }
 
 /// Lightweight representation of a MIDI 2.0 note event.
+@available(*, deprecated, message: "Use `Midi2NoteOn` from the MIDI2 module")
 public struct MIDI2Note: Sendable, Equatable {
     public let channel: Int
     public let note: Int

--- a/Sources/MIDI/MIDI2Facade.swift
+++ b/Sources/MIDI/MIDI2Facade.swift
@@ -1,0 +1,13 @@
+import MIDI2
+
+// Refs: teatro-root
+
+/// Public typealiases exposing key MIDI2 types so clients only need to
+/// import `Teatro`.
+public typealias Midi2ChannelVoiceBody = MIDI2.Midi2ChannelVoiceBody
+public typealias Midi2NoteOn = MIDI2.Midi2NoteOn
+public typealias UtilityBody = MIDI2.UtilityBody
+public typealias SysEx7Packet = MIDI2.SysEx7Packet
+public typealias UmpPacket32 = MIDI2.UmpPacket32
+public typealias UmpPacket64 = MIDI2.UmpPacket64
+public typealias UmpPacket128 = MIDI2.UmpPacket128

--- a/Sources/MIDI/PerNoteController.swift
+++ b/Sources/MIDI/PerNoteController.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Represents a per-note controller value in MIDI 2.0.
+@available(*, deprecated, message: "Use `Midi2RegPerNoteController` from the MIDI2 module")
 public struct PerNoteController: Sendable, Equatable {
     /// Controller index as defined by the MIDI 2.0 specification.
     public let index: UInt8

--- a/Sources/MIDI/PerNotePitchBendEvent.swift
+++ b/Sources/MIDI/PerNotePitchBendEvent.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// Represents a per-note pitch bend in MIDI 2.0.
+@available(*, deprecated, message: "Use `PerNotePitch` from the MIDI2 module")
 public struct PerNotePitchBendEvent: MidiEventProtocol, Sendable, Equatable {
     public let timestamp: UInt32
     public let group: UInt8?


### PR DESCRIPTION
## Summary
- deprecate Teatro-defined MIDI models now superseded by MIDI2 library
- expose key MIDI2 types so `Teatro` users need not import the dependency directly

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689ea901db50833399dc4ae38b2b31a1