### PR TITLE
feat: add TeatroRenderAPI (public render entrypoints + SwiftUI preview hook)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -25,6 +25,8 @@ tasks:
     completed: true
   - name: propose-improvements
     description: suggest refactorings or new features when gaps or bugs are detected
+  - name: expose-render-api
+    description: publish initial TeatroRenderAPI target
 
 policies:
   - ensure commits reference relevant AGENTS instructions

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
             name: "Teatro",
             targets: ["Teatro"]
         ),
+        .library(name: "TeatroRenderAPI", targets: ["TeatroRenderAPI"]),
         .executable(name: "RenderCLI", targets: ["RenderCLI"]),
         .executable(name: "TeatroSamplerDemo", targets: ["TeatroSamplerDemo"]),
         .executable(name: "teatro-play", targets: ["TeatroPlay"])
@@ -23,7 +24,7 @@ let package = Package(
             name: "Teatro",
             dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2")],
             path: "Sources",
-            exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md"],
+            exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md", "TeatroRenderAPI"],
             linkerSettings: [
                 .linkedFramework("AVFoundation", .when(platforms: [.macOS]))
             ]
@@ -54,11 +55,16 @@ let package = Package(
             ],
             path: "Sources/TeatroPlay"
         ),
+        .target(
+            name: "TeatroRenderAPI",
+            dependencies: ["Teatro"],
+            path: "Sources/TeatroRenderAPI"
+        ),
         .testTarget(
             name: "TeatroTests",
             dependencies: ["Teatro"],
             path: "Tests",
-            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests", "SamplerTests", "CLI"],
+            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests", "SamplerTests", "CLI", "TeatroRenderAPITests"],
             resources: [
                 .process("Fixtures")
             ]
@@ -87,6 +93,11 @@ let package = Package(
             name: "CLITests",
             dependencies: ["RenderCLI"],
             path: "Tests/CLI"
+        ),
+        .testTarget(
+            name: "TeatroRenderAPITests",
+            dependencies: ["TeatroRenderAPI"],
+            path: "Tests/TeatroRenderAPITests"
         ),
         .target(
             name: "CCsound",

--- a/Sources/TeatroRenderAPI/Errors.swift
+++ b/Sources/TeatroRenderAPI/Errors.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum RenderError: Error, CustomStringConvertible {
+    case parse(String)
+    case layout(String)
+    case io(String)
+    case unsupported(String)
+
+    public var description: String {
+        switch self {
+        case .parse(let m): return "Parse error: \(m)"
+        case .layout(let m): return "Layout error: \(m)"
+        case .io(let m): return "I/O error: \(m)"
+        case .unsupported(let m): return "Unsupported: \(m)"
+        }
+    }
+}

--- a/Sources/TeatroRenderAPI/Inputs.swift
+++ b/Sources/TeatroRenderAPI/Inputs.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public protocol RenderScriptInput {
+    var fountainText: String { get }
+}
+
+public protocol RenderStoryboardInput {
+    var umpData: Data? { get }
+    var storyboardDSL: String? { get }
+}
+
+public protocol RenderSessionInput {
+    var logText: String { get }
+}
+
+public protocol RenderSearchInput {
+    var query: String { get }
+}
+
+public struct SimpleScriptInput: RenderScriptInput {
+    public let fountainText: String
+    public init(fountainText: String) {
+        self.fountainText = fountainText
+    }
+}
+
+public struct SimpleStoryboardInput: RenderStoryboardInput {
+    public let umpData: Data?
+    public let storyboardDSL: String?
+    public init(umpData: Data? = nil, storyboardDSL: String? = nil) {
+        self.umpData = umpData
+        self.storyboardDSL = storyboardDSL
+    }
+}
+
+public struct SimpleSessionInput: RenderSessionInput {
+    public let logText: String
+    public init(logText: String) {
+        self.logText = logText
+    }
+}
+
+public struct SimpleSearchInput: RenderSearchInput {
+    public let query: String
+    public init(query: String) {
+        self.query = query
+    }
+}

--- a/Sources/TeatroRenderAPI/RenderAPI.swift
+++ b/Sources/TeatroRenderAPI/RenderAPI.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct RenderResult {
+    public let svg: Data?
+    public let markdown: String?
+    public let ump: Data?
+
+    public init(svg: Data? = nil, markdown: String? = nil, ump: Data? = nil) {
+        self.svg = svg
+        self.markdown = markdown
+        self.ump = ump
+    }
+}
+
+public enum TeatroRenderer {
+    /// .fountain -> SVG (+ optional Markdown synopsis)
+    public static func renderScript(_ input: RenderScriptInput) throws -> RenderResult {
+        // 1) Parse Fountain
+        // 2) Layout to SVG
+        // 3) Produce optional synopsis Markdown
+        // return RenderResult(svg: svgData, markdown: synopsis)
+        throw RenderError.unsupported("stub")
+    }
+
+    /// .ump / storyboard DSL -> animated SVG + (re)emitted .ump
+    public static func renderStoryboard(_ input: RenderStoryboardInput) throws -> RenderResult {
+        // 1) Parse UMP or Storyboard DSL
+        // 2) Layout to animated SVG
+        // 3) Return normalized UMP
+        throw RenderError.unsupported("stub")
+    }
+
+    /// .session/log/markdown -> Markdown reflection + overlay markers
+    public static func renderSession(_ input: RenderSessionInput) throws -> RenderResult {
+        // 1) Parse session log
+        // 2) Produce Markdown with overlays
+        throw RenderError.unsupported("stub")
+    }
+
+    /// lightweight search/plan -> Markdown or small SVG panels
+    public static func renderSearch(_ input: RenderSearchInput) throws -> RenderResult {
+        // 1) Search and layout
+        throw RenderError.unsupported("stub")
+    }
+}

--- a/Sources/TeatroRenderAPI/SwiftUI+Preview.swift
+++ b/Sources/TeatroRenderAPI/SwiftUI+Preview.swift
@@ -1,0 +1,18 @@
+#if canImport(SwiftUI) && os(macOS)
+import SwiftUI
+import Foundation
+
+@available(macOS 14, *)
+public struct TeatroPlayerView: View {
+    private let svg: Data
+
+    public init(svg: Data) {
+        self.svg = svg
+    }
+
+    public var body: some View {
+        // Stub preview view; actual SVG rendering will be implemented later.
+        Text("TeatroPlayerView stub")
+    }
+}
+#endif

--- a/Tests/TeatroRenderAPITests/APIConformanceTests.swift
+++ b/Tests/TeatroRenderAPITests/APIConformanceTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import TeatroRenderAPI
+
+final class APIConformanceTests: XCTestCase {
+    func testRenderScriptStub() {
+        let input = SimpleScriptInput(fountainText: "INT. SCENE")
+        XCTAssertThrowsError(try TeatroRenderer.renderScript(input))
+    }
+
+    func testRenderStoryboardStub() {
+        let input = SimpleStoryboardInput()
+        XCTAssertThrowsError(try TeatroRenderer.renderStoryboard(input))
+    }
+
+    func testRenderSessionStub() {
+        let input = SimpleSessionInput(logText: "")
+        XCTAssertThrowsError(try TeatroRenderer.renderSession(input))
+    }
+
+    func testRenderSearchStub() {
+        let input = SimpleSearchInput(query: "")
+        XCTAssertThrowsError(try TeatroRenderer.renderSearch(input))
+    }
+}


### PR DESCRIPTION
## Summary
- stub TeatroRenderAPI target exposing initial render entry points and inputs
- add SwiftUI `TeatroPlayerView` preview hook for macOS
- wire new product, target, and tests in Package.swift

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689ebe8781c08333983da63bafe5a17c