### PR TITLE
feat: render fountain scripts to SVG with synopsis

### DIFF
--- a/Tests/TeatroRenderAPITests/APIConformanceTests.swift
+++ b/Tests/TeatroRenderAPITests/APIConformanceTests.swift
@@ -2,9 +2,16 @@ import XCTest
 @testable import TeatroRenderAPI
 
 final class APIConformanceTests: XCTestCase {
-    func testRenderScriptStub() {
-        let input = SimpleScriptInput(fountainText: "INT. SCENE")
-        XCTAssertThrowsError(try TeatroRenderer.renderScript(input))
+    func testRenderScriptRenders() throws {
+        let script = """
+        INT. SCENE - DAY
+
+        JOHN
+        Hello.
+        """
+        let input = SimpleScriptInput(fountainText: script)
+        let result = try TeatroRenderer.renderScript(input)
+        XCTAssertNotNil(result.svg)
     }
 
     func testRenderStoryboardStub() {

--- a/Tests/TeatroRenderAPITests/ScriptRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/ScriptRenderingTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import TeatroRenderAPI
+
+final class ScriptRenderingTests: XCTestCase {
+    func testRenderScriptProducesSVGAndSynopsis() throws {
+        let script = """
+        = Opening scene
+        INT. HOUSE - DAY
+        
+        JOHN
+        Hello there.
+        """
+        let input = SimpleScriptInput(fountainText: script)
+        let result = try TeatroRenderer.renderScript(input)
+        let svgString = String(data: try XCTUnwrap(result.svg), encoding: .utf8)
+        XCTAssertNotNil(svgString)
+        XCTAssertEqual(result.markdown?.trimmingCharacters(in: .whitespacesAndNewlines), "- Opening scene")
+    }
+}


### PR DESCRIPTION
## Summary
- implement Fountain → SVG pipeline with optional synopsis output
- add API and snapshot tests for Fountain rendering

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689ec85365b08333958d9b5c1708cb26