### PR TITLE
feat: support storyboard UMP rendering

### DIFF
--- a/Tests/TeatroRenderAPITests/APIConformanceTests.swift
+++ b/Tests/TeatroRenderAPITests/APIConformanceTests.swift
@@ -14,9 +14,14 @@ final class APIConformanceTests: XCTestCase {
         XCTAssertNotNil(result.svg)
     }
 
-    func testRenderStoryboardStub() {
-        let input = SimpleStoryboardInput()
-        XCTAssertThrowsError(try TeatroRenderer.renderStoryboard(input))
+    func testRenderStoryboardRenders() throws {
+        let dsl = """
+        Scene: Test
+        Text: Hi
+        """
+        let input = SimpleStoryboardInput(storyboardDSL: dsl)
+        let result = try TeatroRenderer.renderStoryboard(input)
+        XCTAssertNotNil(result.svg)
     }
 
     func testRenderSessionStub() {

--- a/Tests/TeatroRenderAPITests/StoryboardRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/StoryboardRenderingTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import TeatroRenderAPI
+
+final class StoryboardRenderingTests: XCTestCase {
+    func testRenderStoryboardDSLProducesSVG() throws {
+        let dsl = """
+        Scene: Start
+        Text: Hello
+        """
+        let input = SimpleStoryboardInput(storyboardDSL: dsl)
+        let result = try TeatroRenderer.renderStoryboard(input)
+        let svgString = String(data: try XCTUnwrap(result.svg), encoding: .utf8)
+        XCTAssertNotNil(svgString)
+        XCTAssertTrue(svgString?.contains("<svg") ?? false)
+        XCTAssertNil(result.ump)
+    }
+
+    func testRenderStoryboardUMPProducesNormalizedOutput() throws {
+        let words: [UInt32] = [0x40903C00, 0x7FFF0000]
+        var bytes: [UInt8] = []
+        for w in words {
+            bytes.append(UInt8((w >> 24) & 0xFF))
+            bytes.append(UInt8((w >> 16) & 0xFF))
+            bytes.append(UInt8((w >> 8) & 0xFF))
+            bytes.append(UInt8(w & 0xFF))
+        }
+        let data = Data(bytes)
+        let input = SimpleStoryboardInput(umpData: data)
+        let result = try TeatroRenderer.renderStoryboard(input)
+        XCTAssertEqual(result.ump, data)
+        let svgString = String(data: try XCTUnwrap(result.svg), encoding: .utf8)
+        XCTAssertTrue(svgString?.contains("<svg") ?? false)
+    }
+}


### PR DESCRIPTION
## Summary
- animate storyboard DSL or UMP into SVG and emit normalized UMP data
- cover renderStoryboard via API and storyboard tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689ef47867588333bfbe7323a7a9436d