### PR TITLE
feat: render session logs to markdown

### DIFF
--- a/Tests/TeatroRenderAPITests/APIConformanceTests.swift
+++ b/Tests/TeatroRenderAPITests/APIConformanceTests.swift
@@ -24,9 +24,10 @@ final class APIConformanceTests: XCTestCase {
         XCTAssertNotNil(result.svg)
     }
 
-    func testRenderSessionStub() {
-        let input = SimpleSessionInput(logText: "")
-        XCTAssertThrowsError(try TeatroRenderer.renderSession(input))
+    func testRenderSessionRenders() throws {
+        let input = SimpleSessionInput(logText: "$ test\n")
+        let result = try TeatroRenderer.renderSession(input)
+        XCTAssertNotNil(result.markdown)
     }
 
     func testRenderSearchStub() {

--- a/Tests/TeatroRenderAPITests/SessionRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/SessionRenderingTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import TeatroRenderAPI
+
+final class SessionRenderingTests: XCTestCase {
+    func testRenderSessionProducesMarkdownAndMarkers() throws {
+        let log = """
+$ echo hi
+hi
+$ ls
+file
+"""
+        let input = SimpleSessionInput(logText: log)
+        let result = try TeatroRenderer.renderSession(input)
+        let markdown = try XCTUnwrap(result.markdown)
+        XCTAssertTrue(markdown.contains("```session"))
+        XCTAssertTrue(markdown.contains("$ echo hi"))
+        XCTAssertTrue(markdown.contains("\"line\" : 1"))
+        XCTAssertTrue(markdown.contains("\"command\" : \"echo hi\""))
+    }
+}


### PR DESCRIPTION
## Summary
- implement SessionParser-based Markdown renderer with overlay markers
- cover session renderer and API conformance in tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689eff85e38883338f89539c08ced73d