### PR TITLE
feat: implement search renderer

### DIFF
--- a/Sources/TeatroRenderAPI/RenderAPI.swift
+++ b/Sources/TeatroRenderAPI/RenderAPI.swift
@@ -106,8 +106,19 @@ public enum TeatroRenderer {
 
     /// lightweight search/plan -> Markdown or small SVG panels
     public static func renderSearch(_ input: RenderSearchInput) throws -> RenderResult {
-        // 1) Search and layout
-        throw RenderError.unsupported("stub")
+        let lines = input.query.split(separator: "\n", omittingEmptySubsequences: false)
+        var items: [String] = []
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+            if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") {
+                items.append(trimmed)
+            } else {
+                items.append("- \(trimmed)")
+            }
+        }
+        let markdown = items.joined(separator: "\n")
+        return RenderResult(markdown: markdown)
     }
 
     private static func dataFromWords(_ words: [UInt32]) -> Data {

--- a/Tests/TeatroRenderAPITests/APIConformanceTests.swift
+++ b/Tests/TeatroRenderAPITests/APIConformanceTests.swift
@@ -30,8 +30,9 @@ final class APIConformanceTests: XCTestCase {
         XCTAssertNotNil(result.markdown)
     }
 
-    func testRenderSearchStub() {
-        let input = SimpleSearchInput(query: "")
-        XCTAssertThrowsError(try TeatroRenderer.renderSearch(input))
+    func testRenderSearchRenders() throws {
+        let input = SimpleSearchInput(query: "task one\n")
+        let result = try TeatroRenderer.renderSearch(input)
+        XCTAssertNotNil(result.markdown)
     }
 }

--- a/Tests/TeatroRenderAPITests/SearchRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/SearchRenderingTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import TeatroRenderAPI
+
+final class SearchRenderingTests: XCTestCase {
+    func testRenderSearchProducesMarkdownList() throws {
+        let query = "[ ] first task\nsecond task\n- third task"
+        let input = SimpleSearchInput(query: query)
+        let result = try TeatroRenderer.renderSearch(input)
+        let markdown = try XCTUnwrap(result.markdown)
+        XCTAssertEqual(markdown, "- [ ] first task\n- second task\n- third task")
+    }
+}


### PR DESCRIPTION
## Summary
- convert search/plan input lines into markdown checklist items
- add coverage for search rendering

## Testing
- `swift test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_b_689f018856688333aae187a742ac8415