### PR TITLE
feat: add macOS SVG preview hook

### DIFF
--- a/Sources/TeatroRenderAPI/SwiftUI+Preview.swift
+++ b/Sources/TeatroRenderAPI/SwiftUI+Preview.swift
@@ -1,18 +1,44 @@
-#if canImport(SwiftUI) && os(macOS)
+#if canImport(SwiftUI) && canImport(WebKit) && os(macOS)
 import SwiftUI
+import WebKit
 import Foundation
 
-@available(macOS 14, *)
-public struct TeatroPlayerView: View {
+/// Minimal SwiftUI view that previews an SVG document (and future timeline data).
+///
+/// This hook is intentionally lightweight so downstream macOS apps can embed
+/// Teatro's renderer without depending on the full engine. Timeline playback
+/// will be wired up in subsequent iterations.
+@available(macOS 13, *)
+public struct TeatroPlayerView: NSViewRepresentable {
     private let svg: Data
+    private let timeline: Data?
 
-    public init(svg: Data) {
+    /// Creates a preview view for the provided SVG data.
+    /// - Parameters:
+    ///   - svg: Rendered SVG bytes to display.
+    ///   - timeline: Optional timeline data for future animation support.
+    public init(svg: Data, timeline: Data? = nil) {
         self.svg = svg
+        self.timeline = timeline
     }
 
-    public var body: some View {
-        // Stub preview view; actual SVG rendering will be implemented later.
-        Text("TeatroPlayerView stub")
+    public func makeNSView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.setValue(false, forKey: "drawsBackground")
+        loadSVG(into: webView)
+        return webView
+    }
+
+    public func updateNSView(_ nsView: WKWebView, context: Context) {
+        loadSVG(into: nsView)
+    }
+
+    private func loadSVG(into webView: WKWebView) {
+        // Use a blank base URL to allow relative references if any.
+        webView.load(svg,
+                     mimeType: "image/svg+xml",
+                     characterEncodingName: "utf-8",
+                     baseURL: URL(fileURLWithPath: "/"))
     }
 }
 #endif

--- a/Tests/TeatroRenderAPITests/TeatroPlayerViewTests.swift
+++ b/Tests/TeatroRenderAPITests/TeatroPlayerViewTests.swift
@@ -1,0 +1,13 @@
+#if canImport(SwiftUI) && os(macOS)
+import XCTest
+@testable import TeatroRenderAPI
+import SwiftUI
+
+@available(macOS 13, *)
+final class TeatroPlayerViewTests: XCTestCase {
+    func testInstantiation() {
+        let svg = "<svg xmlns='http://www.w3.org/2000/svg' width='1' height='1'></svg>"
+        _ = TeatroPlayerView(svg: Data(svg.utf8))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `TeatroPlayerView` using WebKit to preview SVG and future timeline data on macOS
- add smoke test for `TeatroPlayerView` instantiation

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689f093a56408333bc12b9202213a172