### PR TITLE
test: add RenderAPI snapshots and docs

### DIFF
--- a/Docs/RenderAPI.md
+++ b/Docs/RenderAPI.md
@@ -1,0 +1,40 @@
+# Render API
+
+`TeatroRenderAPI` exposes stable entry points for rendering text-based inputs into SVG or Markdown artifacts.
+
+## Usage
+
+```swift
+import TeatroRenderAPI
+
+let script = """
+= Opening scene
+INT. HOUSE - DAY
+
+JOHN
+Hello there.
+"""
+let result = try TeatroRenderer.renderScript(SimpleScriptInput(fountainText: script))
+let svgData = result.svg       // SVG of the scene
+let synopsis = result.markdown // "- Opening scene"
+```
+
+The API also includes helpers for storyboard UMP data and session logs. Outputs are deterministic to enable snapshot testing.
+
+### SwiftUI Preview
+
+`TeatroPlayerView` provides a lightweight SwiftUI view for displaying rendered SVG on macOS:
+
+```swift
+import SwiftUI
+import TeatroRenderAPI
+
+@available(macOS 13, *)
+struct Preview: View {
+    let svg: Data
+    var body: some View {
+        TeatroPlayerView(svg: svg)
+    }
+}
+```
+

--- a/Package.swift
+++ b/Package.swift
@@ -97,7 +97,10 @@ let package = Package(
         .testTarget(
             name: "TeatroRenderAPITests",
             dependencies: ["TeatroRenderAPI"],
-            path: "Tests/TeatroRenderAPITests"
+            path: "Tests/TeatroRenderAPITests",
+            resources: [
+                .process("__snapshots__")
+            ]
         ),
         .target(
             name: "CCsound",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Teatro is centered on **MIDI 2.0** for sequencing and timing. MIDI 1.0 is supported only as a fallback for legacy export.
 
+## Render API
+
+The `TeatroRenderAPI` module exposes deterministic rendering helpers and a SwiftUI `TeatroPlayerView` for quick previews. See [Docs/RenderAPI.md](Docs/RenderAPI.md) for usage examples.
+
 ## MIDI-CI Discovery
 
 Teatro includes basic support for the MIDI Capability Inquiry (MIDI-CI) protocol.
@@ -41,6 +45,7 @@ The long-form documentation lives under `Docs/Chapters`. Start with the timeline
 
 ## Documentation
 
+- [Render API](Docs/RenderAPI.md)
 - [1. Core Protocols](Docs/Chapters/01_CoreProtocols.md)
 - [2. View Types](Docs/Chapters/02_ViewTypes.md)
 - [3. Rendering Backends](Docs/Chapters/03_RenderingBackends.md)

--- a/Sources/TeatroRenderAPI/RenderAPI.swift
+++ b/Sources/TeatroRenderAPI/RenderAPI.swift
@@ -94,7 +94,7 @@ public enum TeatroRenderer {
 
         var overlaySection = ""
         if !overlays.isEmpty {
-            let data = try JSONSerialization.data(withJSONObject: overlays, options: [.prettyPrinted])
+            let data = try JSONSerialization.data(withJSONObject: overlays, options: [.prettyPrinted, .sortedKeys])
             if let json = String(data: data, encoding: .utf8) {
                 overlaySection = "\n\n```json\n" + json + "\n```"
             }

--- a/Tests/TeatroRenderAPITests/APIConformanceTests.swift
+++ b/Tests/TeatroRenderAPITests/APIConformanceTests.swift
@@ -35,4 +35,11 @@ final class APIConformanceTests: XCTestCase {
         let result = try TeatroRenderer.renderSearch(input)
         XCTAssertNotNil(result.markdown)
     }
+
+    func testRenderResultHasExpectedProperties() {
+        let result = RenderResult()
+        let mirror = Mirror(reflecting: result)
+        let names = Set(mirror.children.compactMap { $0.label })
+        XCTAssertEqual(names, ["svg", "markdown", "ump"])
+    }
 }

--- a/Tests/TeatroRenderAPITests/ScriptRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/ScriptRenderingTests.swift
@@ -2,18 +2,34 @@ import XCTest
 @testable import TeatroRenderAPI
 
 final class ScriptRenderingTests: XCTestCase {
-    func testRenderScriptProducesSVGAndSynopsis() throws {
+    func testRenderScriptMatchesSnapshots() throws {
         let script = """
         = Opening scene
         INT. HOUSE - DAY
-        
+
         JOHN
         Hello there.
         """
         let input = SimpleScriptInput(fountainText: script)
         let result = try TeatroRenderer.renderScript(input)
-        let svgString = String(data: try XCTUnwrap(result.svg), encoding: .utf8)
-        XCTAssertNotNil(svgString)
-        XCTAssertEqual(result.markdown?.trimmingCharacters(in: .whitespacesAndNewlines), "- Opening scene")
+
+        let snapshots = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("__snapshots__", isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshots, withIntermediateDirectories: true)
+        let svgURL = snapshots.appendingPathComponent("Script.svg")
+        let mdURL = snapshots.appendingPathComponent("Script.md")
+
+        if !FileManager.default.fileExists(atPath: svgURL.path) ||
+            !FileManager.default.fileExists(atPath: mdURL.path) {
+            try result.svg?.write(to: svgURL)
+            try result.markdown?.write(to: mdURL, atomically: true, encoding: .utf8)
+            XCTFail("Snapshot files created; re-run tests")
+        } else {
+            let expectedSVG = try Data(contentsOf: svgURL)
+            XCTAssertEqual(result.svg, expectedSVG)
+            let expectedMD = try String(contentsOf: mdURL)
+            XCTAssertEqual(result.markdown, expectedMD)
+        }
     }
 }

--- a/Tests/TeatroRenderAPITests/__snapshots__/Script.md
+++ b/Tests/TeatroRenderAPITests/__snapshots__/Script.md
@@ -1,0 +1,1 @@
+- Opening scene

--- a/Tests/TeatroRenderAPITests/__snapshots__/Script.svg
+++ b/Tests/TeatroRenderAPITests/__snapshots__/Script.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400">
+<text x="10" y="20" font-family="monospace" font-size="14">= Opening scene</text>
+<text x="10" y="40" font-family="monospace" font-size="14"># INT. HOUSE - DAY</text>
+<text x="10" y="60" font-family="monospace" font-size="14"></text>
+<text x="10" y="80" font-family="monospace" font-size="14">JOHN</text>
+<text x="10" y="100" font-family="monospace" font-size="14">	Hello there.</text>
+</svg>

--- a/Tests/TeatroRenderAPITests/__snapshots__/Session.md
+++ b/Tests/TeatroRenderAPITests/__snapshots__/Session.md
@@ -1,0 +1,19 @@
+```session
+$ echo hi
+hi
+$ ls
+file
+```
+
+```json
+[
+  {
+    "command" : "echo hi",
+    "line" : 1
+  },
+  {
+    "command" : "ls",
+    "line" : 3
+  }
+]
+```


### PR DESCRIPTION
## Summary
- wire TeatroRenderAPITests resources in Package.swift
- add snapshot and API conformance tests
- document RenderAPI and mention module in README

## Testing
- `swift test --filter ScriptRenderingTests.testRenderScriptMatchesSnapshots`
- `swift test --filter SessionRenderingTests.testRenderSessionMatchesSnapshot`
- `swift test --filter TeatroRenderAPITests`

------
https://chatgpt.com/codex/tasks/task_b_689f0bffc9788333bd1c2eef3fc0f221