### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.2.0] - 2025-08-15
+- Bump minor version to 0.2.0.
+
+## [0.1.0]
+- Initial release.

--- a/Sources/CLI/RenderCLI.swift
+++ b/Sources/CLI/RenderCLI.swift
@@ -15,7 +15,7 @@ import Darwin
 public struct RenderCLI: ParsableCommand {
     public static let configuration = CommandConfiguration(
         abstract: "Render Teatro views from scripts, scores, and storyboards.",
-        version: "0.1.0"
+        version: "0.2.0"
     )
 
     @Argument(help: "Input file path. Supported: .fountain, .ly, .mid/.midi, .ump, .csd, .storyboard, .session")

--- a/Teatro.podspec
+++ b/Teatro.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Teatro'
-  s.version      = '0.1.0'
+  s.version      = '0.2.0'
   s.summary      = 'Declarative rendering framework.'
   s.homepage     = 'https://github.com/fountain-coach/teatro'
   s.license      = { :type => 'MIT' }

--- a/Tests/CLI/RenderCLICoverageTests.swift
+++ b/Tests/CLI/RenderCLICoverageTests.swift
@@ -303,7 +303,7 @@ final class RenderCLICoverageTests: XCTestCase {
         process.waitUntilExit()
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(decoding: data, as: UTF8.self)
-        XCTAssertTrue(output.contains("0.1.0"))
+        XCTAssertTrue(output.contains("0.2.0"))
     }
 }
 

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -41,7 +41,7 @@ final class RenderCLITests: XCTestCase {
     }
 
     func testVersionFlag() {
-        XCTAssertVersion(RenderCLI.self, "0.1.0")
+        XCTAssertVersion(RenderCLI.self, "0.2.0")
     }
 
     func testUnknownFlag() {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Teatro CLI
-  version: "0.1.0"
+  version: "0.2.0"
   description: |
     HTTP façade for the Teatro RenderCLI. Converts scripts, scores, or storyboards
     into various render targets (HTML, SVG, PNG, Markdown, Codex, animated SVG,


### PR DESCRIPTION
## Summary
- bump project version to 0.2.0 and document in CHANGELOG
- sync CLI, podspec, and OpenAPI spec with new version
- adjust tests for updated version

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689f0f2bc6348333b8c95b59d68428aa