### PR TITLE
Migrate to MIDI2 v0.3 with Swift 6.1 concurrency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "83cf2fd4125154233bc7a10b95e76999cb577a18a159340156fb9a28518270f0",
+  "originHash" : "af4899004ae04ff7cc5bb53ff9aedc156d1fb387b14ca12a01ceacd63b9aa529",
   "pins" : [
     {
       "identity" : "midi2",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Fountain-Coach/midi2",
       "state" : {
-        "revision" : "91812a2a267a7d4248ce22303ff653b39ddae260",
-        "version" : "0.2.0"
+        "revision" : "8fb9904495e4e9296e86e41ac3df05addef212a1",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-tools-support-core", from: "0.6.0"),
-        .package(url: "https://github.com/Fountain-Coach/midi2", from: "0.2.0")
+        .package(url: "https://github.com/Fountain-Coach/midi2", from: "0.3.0")
     ],
     targets: [
         .target(
@@ -25,6 +25,13 @@ let package = Package(
             dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2")],
             path: "Sources",
             exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md", "TeatroRenderAPI"],
+            swiftSettings: [
+                .unsafeFlags([
+                    "-Xfrontend", "-strict-concurrency=complete",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-warn-concurrency"
+                ], .when(configuration: .debug))
+            ],
             linkerSettings: [
                 .linkedFramework("AVFoundation", .when(platforms: [.macOS]))
             ]
@@ -53,7 +60,15 @@ let package = Package(
                 "Teatro",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
-            path: "Sources/TeatroPlay"
+            path: "Sources/TeatroPlay",
+            swiftSettings: [
+                .unsafeFlags([
+                    "-parse-as-library",
+                    "-Xfrontend", "-strict-concurrency=complete",
+                    "-Xfrontend", "-enable-actor-data-race-checks",
+                    "-Xfrontend", "-warn-concurrency"
+                ], .when(configuration: .debug))
+            ]
         ),
         .target(
             name: "TeatroRenderAPI",

--- a/Sources/MIDI/MidiEventView.swift
+++ b/Sources/MIDI/MidiEventView.swift
@@ -29,8 +29,8 @@ public struct MidiEventView: Renderable {
             case .perNoteController:
                 let ctrl = (event as? PerNoteControllerEvent)?.controllerIndex ?? 0
                 parts.append("pnc \(event.noteNumber ?? 0) c\(ctrl) \(event.controllerValue ?? 0)")
-            case .perNotePitchBend:
-                parts.append("pnpb \(event.noteNumber ?? 0) \(event.controllerValue ?? 0)")
+            case .perNotePitch:
+                parts.append("pnp \(event.noteNumber ?? 0) \(event.controllerValue ?? 0)")
             case .rpn:
                 if let e = event as? RegisteredParameterNumber {
                     parts.append("rpn \(e.parameter) \(e.value)")

--- a/Sources/MIDI/PerNotePitch.swift
+++ b/Sources/MIDI/PerNotePitch.swift
@@ -1,13 +1,12 @@
 import Foundation
 
-/// Represents a per-note pitch bend in MIDI 2.0.
-@available(*, deprecated, message: "Use `PerNotePitch` from the MIDI2 module")
-public struct PerNotePitchBendEvent: MidiEventProtocol, Sendable, Equatable {
+/// Represents a per-note pitch in MIDI 2.0.
+public struct PerNotePitch: MidiEventProtocol, Sendable, Equatable {
     public let timestamp: UInt32
     public let group: UInt8?
     public let channel: UInt8?
     public let noteNumber: UInt8?
-    /// 32-bit pitch bend value.
+    /// 32-bit pitch value.
     public let pitch: UInt32
 
     public init(timestamp: UInt32 = 0,
@@ -22,7 +21,7 @@ public struct PerNotePitchBendEvent: MidiEventProtocol, Sendable, Equatable {
         self.pitch = pitch
     }
 
-    public var type: MidiEventType { .perNotePitchBend }
+    public var type: MidiEventType { .perNotePitch }
     public var velocity: UInt32? { nil }
     public var controllerValue: UInt32? { pitch }
     public var metaType: UInt8? { nil }

--- a/Sources/MIDI/UMPEncoder.swift
+++ b/Sources/MIDI/UMPEncoder.swift
@@ -51,14 +51,14 @@ public struct UMPEncoder {
             let noteBits = UInt32((event.noteNumber ?? 0) & 0x7F) << 8
             let word1 = messageType | groupBits | (0x0 << 20) | channelBits | noteBits | UInt32(ctrl.controllerIndex)
             return [word1, ctrl.controllerValue ?? 0]
-        case .perNotePitchBend:
-            guard let bend = event as? PerNotePitchBendEvent else { return [] }
+        case .perNotePitch:
+            guard let pn = event as? PerNotePitch else { return [] }
             let messageType: UInt32 = 0x4 << 28
             let groupBits = UInt32((event.group ?? defaultGroup) & 0xF) << 24
             let channelBits = UInt32((event.channel ?? 0) & 0xF) << 16
             let noteBits = UInt32((event.noteNumber ?? 0) & 0x7F) << 8
             let word1 = messageType | groupBits | (0x2 << 20) | channelBits | noteBits
-            return [word1, bend.pitch]
+            return [word1, pn.pitch]
         case .rpn:
             guard let r = event as? RegisteredParameterNumber else { return [] }
             let messageType: UInt32 = 0x4 << 28

--- a/Sources/Parsers/MidiEvents.swift
+++ b/Sources/Parsers/MidiEvents.swift
@@ -16,7 +16,7 @@ public enum MidiEventType {
     case noteEnd
     case pitchClamp
     case pitchRelease
-    case perNotePitchBend
+    case perNotePitch
     case rpn
     case nrpn
     case jrTimestamp

--- a/Sources/Parsers/UMPParser.swift
+++ b/Sources/Parsers/UMPParser.swift
@@ -159,7 +159,7 @@ public struct UMPParser {
                 return ChannelVoiceEvent(timestamp: timestamp, type: .pitchBend, group: group, channel: channel, noteNumber: nil, velocity: nil, controllerValue: data2)
             case 0x20:
                 let note = UInt8((data1 >> 8) & 0xFF)
-                return PerNotePitchBendEvent(timestamp: timestamp, group: group, channel: channel, noteNumber: note, pitch: data2)
+                return PerNotePitch(timestamp: timestamp, group: group, channel: channel, noteNumber: note, pitch: data2)
             case 0x60:
                 let msb = UInt8((data1 >> 8) & 0x7F)
                 let lsb = UInt8(data1 & 0x7F)

--- a/Sources/TeatroPlay/TeatroApp.swift
+++ b/Sources/TeatroPlay/TeatroApp.swift
@@ -1,0 +1,65 @@
+import Foundation
+import ArgumentParser
+import Teatro
+
+struct TeatroApp {
+    struct Options: ParsableArguments {
+        @Flag(name: .long, help: "Read input from stdin")
+        var fromStdin: Bool = false
+
+        @Option(name: .long, help: "Input file path")
+        var input: String?
+
+        @Option(name: .long, help: "Audio sink to use (fluidsynth or sfizz)")
+        var sink: String = "fluidsynth"
+
+        @Option(name: .long, help: "Path to an SF2 SoundFont for FluidSynth")
+        var sf2: String?
+
+        @Option(name: .long, help: "Path to an SFZ preset for Sfizz")
+        var sfz: String?
+    }
+
+    let options: Options
+
+    init() throws {
+        self.options = try Options.parse()
+    }
+
+    func run() async throws {
+        let data: Data
+        if let path = options.input {
+            data = try Data(contentsOf: URL(fileURLWithPath: path))
+        } else if options.fromStdin {
+            data = FileHandle.standardInput.readDataToEndOfFile()
+        } else {
+            throw ValidationError("Provide --input or --from-stdin")
+        }
+
+        let audioSink: MIDIAudioSink
+        switch options.sink.lowercased() {
+        case "fluidsynth":
+            let font = options.sf2 ?? "assets/example.sf2"
+            audioSink = try FluidSynthSink(sf2Path: font)
+        case "sfizz":
+            let preset = options.sfz ?? ""
+            audioSink = SfizzSink(sfzPath: preset)
+        default:
+            throw ValidationError("Unsupported sink \(options.sink)")
+        }
+
+        if data.count % 4 == 0 {
+            try MIDI1Bridge.umpToMIDI1(data, sink: audioSink)
+        } else {
+            let words = MIDI1Bridge.midi1ToUMP(data)
+            var umpData = Data()
+            for w in words {
+                var be = w.bigEndian
+                withUnsafeBytes(of: &be) { umpData.append(contentsOf: $0) }
+            }
+            try MIDI1Bridge.umpToMIDI1(umpData, sink: audioSink)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/TeatroPlay/main.swift
+++ b/Sources/TeatroPlay/main.swift
@@ -1,69 +1,17 @@
 import Foundation
-import ArgumentParser
-import Teatro
-
-// Refs: teatro-root
 
 @main
 struct TeatroPlay {
-    /// Single, explicit async entry point with no top-level execution elsewhere.
-    @MainActor
-    static func main() async {
-        do {
-            let options = try Options.parse()
-            let data: Data
-            if let path = options.input {
-                data = try Data(contentsOf: URL(fileURLWithPath: path))
-            } else if options.fromStdin {
-                data = FileHandle.standardInput.readDataToEndOfFile()
-            } else {
-                throw ValidationError("Provide --input or --from-stdin")
-            }
-
-            let audioSink: MIDIAudioSink
-            switch options.sink.lowercased() {
-            case "fluidsynth":
-                let font = options.sf2 ?? "assets/example.sf2"
-                audioSink = try FluidSynthSink(sf2Path: font)
-            case "sfizz":
-                let preset = options.sfz ?? ""
-                audioSink = SfizzSink(sfzPath: preset)
-            default:
-                throw ValidationError("Unsupported sink \(options.sink)")
-            }
-
-            if data.count % 4 == 0 {
-                try MIDI1Bridge.umpToMIDI1(data, sink: audioSink)
-            } else {
-                let words = MIDI1Bridge.midi1ToUMP(data)
-                var umpData = Data()
-                for w in words {
-                    var be = w.bigEndian
-                    withUnsafeBytes(of: &be) { umpData.append(contentsOf: $0) }
-                }
-                try MIDI1Bridge.umpToMIDI1(umpData, sink: audioSink)
-            }
-        } catch {
-            FileHandle.standardError.write(Data("TeatroPlay failed: \(error)\n".utf8))
-        }
+  /// Explicit, concurrency-safe entry point. No top-level execution elsewhere.
+  @MainActor
+  static func main() async {
+    do {
+      let app = try TeatroApp()
+      try await app.run()
+    } catch {
+      FileHandle.standardError.write(Data("TeatroPlay failed: \(error)\n".utf8))
+      // Optionally: exit(EXIT_FAILURE)
     }
-
-    struct Options: ParsableArguments {
-        @Flag(name: .long, help: "Read input from stdin")
-        var fromStdin: Bool = false
-
-        @Option(name: .long, help: "Input file path")
-        var input: String?
-
-        @Option(name: .long, help: "Audio sink to use (fluidsynth or sfizz)")
-        var sink: String = "fluidsynth"
-
-        @Option(name: .long, help: "Path to an SF2 SoundFont for FluidSynth")
-        var sf2: String?
-
-        @Option(name: .long, help: "Path to an SFZ preset for Sfizz")
-        var sfz: String?
-    }
+  }
 }
 
-// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -118,7 +118,7 @@ final class RenderCLITests: XCTestCase {
 
     func testMidiFixtureFileParses() throws {
         let fixtures = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Fixtures")
-        let base64 = try String(contentsOf: fixtures.appendingPathComponent("sample.mid")).components(separatedBy: "\n").first ?? ""
+        let base64 = try String(contentsOf: fixtures.appendingPathComponent("sample.mid"), encoding: .utf8).components(separatedBy: "\n").first ?? ""
         let data = Data(base64Encoded: base64)!
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("fixture.mid")
         try data.write(to: url)
@@ -261,7 +261,7 @@ final class RenderCLITests: XCTestCase {
             """.write(to: input, atomically: true, encoding: .utf8)
         }
         DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
-            if let contents = try? String(contentsOf: output), contents.contains("Changed") {
+            if let contents = try? String(contentsOf: output, encoding: .utf8), contents.contains("Changed") {
                 exp.fulfill()
             }
         }
@@ -293,7 +293,7 @@ final class RenderCLITests: XCTestCase {
             """.write(to: input, atomically: true, encoding: .utf8)
         }
         DispatchQueue.global().asyncAfter(deadline: .now() + 3.0) {
-            if let contents = try? String(contentsOf: output), contents.contains("Changed") {
+            if let contents = try? String(contentsOf: output, encoding: .utf8), contents.contains("Changed") {
                 exp.fulfill()
             }
         }

--- a/Tests/MIDITests/MIDI2Tests.swift
+++ b/Tests/MIDITests/MIDI2Tests.swift
@@ -130,11 +130,11 @@ final class MIDI2Tests: XCTestCase {
         XCTAssertEqual(encoded, words)
     }
 
-    func testRoundTripPerNotePitchBendFromSpec() throws {
+    func testRoundTripPerNotePitchFromSpec() throws {
         let words: [UInt32] = [0x40203C00, 0x12345678]
         let events = try UMPParser.parse(data: Data(bytes(from: words)))
-        guard let bend = events.first as? PerNotePitchBendEvent else {
-            return XCTFail("Expected PerNotePitchBendEvent")
+        guard let bend = events.first as? Teatro.PerNotePitch else {
+            return XCTFail("Expected PerNotePitch")
         }
         XCTAssertEqual(bend.noteNumber, 0x3C)
         XCTAssertEqual(bend.pitch, 0x12345678)

--- a/Tests/MIDITests/MIDITests.swift
+++ b/Tests/MIDITests/MIDITests.swift
@@ -17,7 +17,7 @@ final class MIDITests: XCTestCase {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("mid")
         MIDIRenderer.renderToFile(seq, to: url.path)
         XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
-        let content = try String(contentsOf: url)
+        let content = try String(contentsOf: url, encoding: .utf8)
         XCTAssertTrue(content.contains("NOTE"))
     }
 }

--- a/Tests/SessionParserTests.swift
+++ b/Tests/SessionParserTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class SessionParserTests: XCTestCase {
     func testParsesRawText() throws {
         let url = Bundle.module.url(forResource: "sample", withExtension: "session")!
-        let text = try String(contentsOf: url)
+        let text = try String(contentsOf: url, encoding: .utf8)
         let session = SessionParser.parse(text)
         XCTAssertEqual(session.text, text)
         XCTAssertEqual(session.render(), text)

--- a/Tests/TeatroRenderAPITests/ScriptRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/ScriptRenderingTests.swift
@@ -28,7 +28,7 @@ final class ScriptRenderingTests: XCTestCase {
         } else {
             let expectedSVG = try Data(contentsOf: svgURL)
             XCTAssertEqual(result.svg, expectedSVG)
-            let expectedMD = try String(contentsOf: mdURL)
+            let expectedMD = try String(contentsOf: mdURL, encoding: .utf8)
             XCTAssertEqual(result.markdown, expectedMD)
         }
     }

--- a/Tests/TeatroRenderAPITests/SessionRenderingTests.swift
+++ b/Tests/TeatroRenderAPITests/SessionRenderingTests.swift
@@ -22,7 +22,7 @@ file
             try result.markdown?.write(to: mdURL, atomically: true, encoding: .utf8)
             XCTFail("Snapshot file created; re-run tests")
         } else {
-            let expected = try String(contentsOf: mdURL)
+            let expected = try String(contentsOf: mdURL, encoding: .utf8)
             XCTAssertEqual(result.markdown, expected)
         }
     }


### PR DESCRIPTION
## Summary
- Normalize teatro-play entry point with async @main and Teat­roApp wrapper
- Replace deprecated PerNotePitchBendEvent with PerNotePitch and update encoders/parsers
- Enable strict concurrency and actor race checks for Teatro and teatro-play targets
- Fix tests and file I/O warnings for Swift 6.1

## Testing
- `swift build -v`
- `swift test --parallel`


------
https://chatgpt.com/codex/tasks/task_b_68a019ef43a08333b44c4472df9de39c