### PR TITLE
Fix MainActor test and update AbsolutePath initializers

### DIFF
--- a/Tests/CLI/RenderCLITests.swift
+++ b/Tests/CLI/RenderCLITests.swift
@@ -252,7 +252,7 @@ final class RenderCLITests: XCTestCase {
             try? FileManager.default.removeItem(at: output)
         }
         let cli = RenderCLI()
-        let source = cli.watchFile(path: input.path, target: MarkdownRenderer.self, outputPath: output.path)
+        let source = try cli.watchFile(path: input.path, target: MarkdownRenderer.self, outputPath: output.path)
         let exp = expectation(description: "rerender")
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
             try? """
@@ -284,7 +284,7 @@ final class RenderCLITests: XCTestCase {
             try? FileManager.default.removeItem(at: output)
         }
         let cli = RenderCLI()
-        let source = cli.watchFile(path: input.path, target: MarkdownRenderer.self, outputPath: output.path)
+        let source = try cli.watchFile(path: input.path, target: MarkdownRenderer.self, outputPath: output.path)
         let exp = expectation(description: "rerender")
         DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) {
             try? """

--- a/Tests/TeatroRenderAPITests/TeatroPlayerViewTests.swift
+++ b/Tests/TeatroRenderAPITests/TeatroPlayerViewTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import SwiftUI
 
 @available(macOS 13, *)
+@MainActor
 final class TeatroPlayerViewTests: XCTestCase {
     func testInstantiation() {
         let svg = "<svg xmlns='http://www.w3.org/2000/svg' width='1' height='1'></svg>"


### PR DESCRIPTION
## Summary
- run `TeatroPlayerViewTests` on the `MainActor` to satisfy strict concurrency
- adopt throwing `AbsolutePath(validating:)` initializers in CLI watch utility
- adjust CLI watch-mode tests for throwing API

## Testing
- `swift build -v`
- `swift test --parallel --enable-xctest --disable-swift-testing`


------
https://chatgpt.com/codex/tasks/task_b_68a01e356d0c83338499eaee59ce896b