### PR TITLE
Fix watchFile error handling in CLITests

### DIFF
--- a/Tests/CLI/RenderCLICoverageTests.swift
+++ b/Tests/CLI/RenderCLICoverageTests.swift
@@ -248,12 +248,12 @@ final class RenderCLICoverageTests: XCTestCase {
     }
 
     #if canImport(Darwin)
-    func testWatchFileDarwinReturnsSource() {
+    func testWatchFileDarwinReturnsSource() throws {
         let cli = RenderCLI()
         let url = tempURL("watch.txt")
         FileManager.default.createFile(atPath: url.path, contents: Data())
         defer { try? FileManager.default.removeItem(at: url) }
-        let source = cli.watchFile(path: url.path, target: MarkdownRenderer.self, outputPath: nil)
+        let source = try cli.watchFile(path: url.path, target: MarkdownRenderer.self, outputPath: nil)
         XCTAssertNotNil(source)
         source?.cancel()
     }


### PR DESCRIPTION
## Summary
- Handle throwing watchFile call in `RenderCLICoverageTests` by marking the test `throws` and using `try`
- Ensure all test watchFile invocations properly propagate errors

## Testing
- `swift build -v`
- `swift test --parallel`


------
https://chatgpt.com/codex/tasks/task_b_68a020a702008333a30f5d635b73e82a