### PR TITLE
Add Fountain SSE envelope with JSON & CBOR helpers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "af4899004ae04ff7cc5bb53ff9aedc156d1fb387b14ca12a01ceacd63b9aa529",
+  "originHash" : "63ac13726ca1871566ae71754fab78870004ca3d59c41a05d22676003285a28c",
   "pins" : [
     {
       "identity" : "midi2",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "e8fbc8b05a155f311b862178d92d043afb216fe3",
         "version" : "0.7.3"
+      }
+    },
+    {
+      "identity" : "swiftcbor",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/unrelentingtech/SwiftCBOR",
+      "state" : {
+        "revision" : "04ccff117f6549121d5721ec84fdf0162122b90e",
+        "version" : "0.5.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,12 +17,13 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
         .package(url: "https://github.com/swiftlang/swift-tools-support-core", from: "0.6.0"),
-        .package(url: "https://github.com/Fountain-Coach/midi2", from: "0.3.0")
+        .package(url: "https://github.com/Fountain-Coach/midi2", from: "0.3.0"),
+        .package(url: "https://github.com/unrelentingtech/SwiftCBOR", from: "0.5.0")
     ],
     targets: [
         .target(
             name: "Teatro",
-            dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2")],
+            dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2"), "SwiftCBOR"],
             path: "Sources",
             exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md", "TeatroRenderAPI"],
             resources: [

--- a/Sources/MIDI/SSE/FountainSSEEnvelope.swift
+++ b/Sources/MIDI/SSE/FountainSSEEnvelope.swift
@@ -1,5 +1,110 @@
-// Placeholder for fountain SSE envelope handling.
-// Added per teatro-root policy.
-public struct FountainSSEEnvelope {
-    public init() {}
+import Foundation
+import SwiftCBOR
+
+/// Envelope for FountainAI Server-Sent Events transported over MIDI.
+///
+/// Version 1 schema:
+/// ```json
+/// {
+///   "v": 1,
+///   "ev": "message" | "error" | "done" | "ctrl",
+///   "id": "optional",
+///   "ct": "application/json",
+///   "seq": 123456,
+///   "frag": { "i": 0, "n": 3 },
+///   "ts": 1724142123.123,
+///   "data": "<payload or slice>"
+/// }
+/// ```
+public struct FountainSSEEnvelope: Codable, Equatable {
+    public enum Event: String, Codable {
+        case message
+        case error
+        case done
+        case ctrl
+    }
+
+    public struct Fragment: Codable, Equatable {
+        public var i: UInt32
+        public var n: UInt32
+        public init(i: UInt32, n: UInt32) {
+            self.i = i
+            self.n = n
+        }
+    }
+
+    public var v: UInt16
+    public var ev: Event
+    public var id: String?
+    public var ct: String?
+    public var seq: UInt64
+    public var frag: Fragment?
+    public var ts: Double?
+    public var data: String?
+
+    public init(
+        v: UInt16 = 1,
+        ev: Event,
+        id: String? = nil,
+        ct: String? = nil,
+        seq: UInt64,
+        frag: Fragment? = nil,
+        ts: Double? = nil,
+        data: String? = nil
+    ) {
+        self.v = v
+        self.ev = ev
+        self.id = id
+        self.ct = ct
+        self.seq = seq
+        self.frag = frag
+        self.ts = ts
+        self.data = data
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case v, ev, id, ct, seq, frag, ts, data
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(UInt16.self, forKey: .v)
+        guard version == 1 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .v,
+                in: container,
+                debugDescription: "Unsupported envelope version \(version)"
+            )
+        }
+        self.v = version
+        self.ev = try container.decode(Event.self, forKey: .ev)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.ct = try container.decodeIfPresent(String.self, forKey: .ct)
+        self.seq = try container.decode(UInt64.self, forKey: .seq)
+        self.frag = try container.decodeIfPresent(Fragment.self, forKey: .frag)
+        self.ts = try container.decodeIfPresent(Double.self, forKey: .ts)
+        self.data = try container.decodeIfPresent(String.self, forKey: .data)
+    }
+
+    // JSON helpers
+    public func encodeJSON() throws -> Data {
+        let encoder = JSONEncoder()
+        return try encoder.encode(self)
+    }
+
+    public static func decodeJSON(_ data: Data) throws -> FountainSSEEnvelope {
+        let decoder = JSONDecoder()
+        return try decoder.decode(FountainSSEEnvelope.self, from: data)
+    }
+
+    // CBOR helpers
+    public func encodeCBOR() throws -> Data {
+        let encoder = CodableCBOREncoder()
+        return try encoder.encode(self)
+    }
+
+    public static func decodeCBOR(_ data: Data) throws -> FountainSSEEnvelope {
+        let decoder = CodableCBORDecoder()
+        return try decoder.decode(FountainSSEEnvelope.self, from: data)
+    }
 }

--- a/Tests/MIDITests/FountainSSEEnvelopeTests.swift
+++ b/Tests/MIDITests/FountainSSEEnvelopeTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Teatro
+
+// Tests required by teatro-root agent policy to ensure SSE envelopes round-trip.
+
+final class FountainSSEEnvelopeTests: XCTestCase {
+    func testJSONRoundTrip() throws {
+        let env = FountainSSEEnvelope(
+            ev: .message,
+            id: "abc",
+            ct: "text/plain",
+            seq: 42,
+            frag: .init(i: 0, n: 1),
+            ts: 1.23,
+            data: "hello"
+        )
+        let encoded = try env.encodeJSON()
+        let decoded = try FountainSSEEnvelope.decodeJSON(encoded)
+        XCTAssertEqual(decoded, env)
+    }
+
+    func testCBORRoundTrip() throws {
+        let env = FountainSSEEnvelope(
+            ev: .ctrl,
+            seq: 7,
+            data: "{\"ack\":1}"
+        )
+        let encoded = try env.encodeCBOR()
+        let decoded = try FountainSSEEnvelope.decodeCBOR(encoded)
+        XCTAssertEqual(decoded, env)
+    }
+
+    func testInvalidEventRejected() throws {
+        let json = """
+        {"v":1,"ev":"bogus","seq":1}
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try FountainSSEEnvelope.decodeJSON(json))
+    }
+}


### PR DESCRIPTION
## Summary
- model FountainSSEEnvelope with versioned fields and encoding helpers
- support JSON and CBOR round-tripping
- cover envelope serialization and invalid cases with unit tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a71f52b2f48333a9be606806493c48