### PR TITLE
feat: publish ordered SSE envelopes

### DIFF
--- a/Sources/MIDI/SSE/FountainSSEDispatcher.swift
+++ b/Sources/MIDI/SSE/FountainSSEDispatcher.swift
@@ -1,4 +1,99 @@
-// Placeholder for fountain SSE dispatcher.
-public struct FountainSSEDispatcher {
-    public init() {}
+import Foundation
+
+// Refs: teatro-root
+
+/// Dispatcher that assembles `FountainSSEEnvelope` fragments carried over
+/// MIDI 2.0 Flex Data or SysEx8 packets and publishes complete envelopes in
+/// sequence order using an async stream.
+public actor FountainSSEDispatcher {
+    /// Async stream of reassembled envelopes.
+    public nonisolated let events: AsyncStream<FountainSSEEnvelope>
+
+    private let continuation: AsyncStream<FountainSSEEnvelope>.Continuation
+
+    /// Buffers for fragments keyed by sequence number.
+    private var fragmentBuffers: [UInt64: [UInt32: FountainSSEEnvelope]] = [:]
+
+    /// Completed envelopes waiting to be published in sequence order.
+    private var ready: [UInt64: FountainSSEEnvelope] = [:]
+
+    /// Next expected sequence number.
+    private var nextSeq: UInt64?
+
+    public init() {
+        var cont: AsyncStream<FountainSSEEnvelope>.Continuation!
+        self.events = AsyncStream<FountainSSEEnvelope> { c in
+            cont = c
+        }
+        self.continuation = cont
+    }
+
+    /// Consume a Flex Data fragment.
+    public func receiveFlex(_ data: Data) throws {
+        try handle(data)
+    }
+
+    /// Consume a SysEx8 fragment.
+    public func receiveSysEx8(_ data: Data) throws {
+        try handle(data)
+    }
+
+    // MARK: - Internal helpers
+
+    private func handle(_ data: Data) throws {
+        let env = try decodeEnvelope(from: data)
+        ingest(env)
+    }
+
+    private func decodeEnvelope(from data: Data) throws -> FountainSSEEnvelope {
+        if let env = try? FountainSSEEnvelope.decodeJSON(data) {
+            return env
+        }
+        return try FountainSSEEnvelope.decodeCBOR(data)
+    }
+
+    private func ingest(_ env: FountainSSEEnvelope) {
+        if let frag = env.frag {
+            var dict = fragmentBuffers[env.seq, default: [:]]
+            dict[frag.i] = env
+            fragmentBuffers[env.seq] = dict
+            if dict.count == frag.n {
+                // Reassemble fragments once all pieces are present.
+                let ordered = dict.values.sorted { ($0.frag?.i ?? 0) < ($1.frag?.i ?? 0) }
+                var merged = ordered.first!
+                merged.frag = nil
+                let combined = ordered.compactMap { $0.data }.joined()
+                merged.data = combined
+                fragmentBuffers.removeValue(forKey: env.seq)
+                ready[env.seq] = merged
+                updateAndPublish(for: env.seq)
+            }
+        } else {
+            ready[env.seq] = env
+            updateAndPublish(for: env.seq)
+        }
+    }
+
+    private func publishReady() {
+        if nextSeq == nil {
+            nextSeq = ready.keys.min()
+        }
+        while let seq = nextSeq, let env = ready[seq] {
+            continuation.yield(env)
+            ready.removeValue(forKey: seq)
+            nextSeq = seq &+ 1
+        }
+    }
+
+    private func updateAndPublish(for seq: UInt64) {
+        if let current = nextSeq {
+            if seq < current { nextSeq = seq }
+            publishReady()
+        } else {
+            nextSeq = seq
+        }
+    }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/Sources/MIDI/SSE/FountainSSEEnvelope.swift
+++ b/Sources/MIDI/SSE/FountainSSEEnvelope.swift
@@ -16,15 +16,15 @@ import SwiftCBOR
 ///   "data": "<payload or slice>"
 /// }
 /// ```
-public struct FountainSSEEnvelope: Codable, Equatable {
-    public enum Event: String, Codable {
+public struct FountainSSEEnvelope: Codable, Equatable, Sendable {
+    public enum Event: String, Codable, Sendable {
         case message
         case error
         case done
         case ctrl
     }
 
-    public struct Fragment: Codable, Equatable {
+    public struct Fragment: Codable, Equatable, Sendable {
         public var i: UInt32
         public var n: UInt32
         public init(i: UInt32, n: UInt32) {

--- a/Tests/MIDITests/FountainSSEDispatcherTests.swift
+++ b/Tests/MIDITests/FountainSSEDispatcherTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Teatro
+
+// Refs: teatro-root
+
+final class FountainSSEDispatcherTests: XCTestCase {
+    func testFragmentationAndOutOfOrderDelivery() async throws {
+        let dispatcher = FountainSSEDispatcher()
+
+        // Sequence 2 arrives first as a complete Flex packet.
+        let env2 = FountainSSEEnvelope(ev: .message, seq: 2, data: "World")
+        let seq2Data = try env2.encodeJSON()
+
+        // Sequence 1 is fragmented across two SysEx8 packets delivered out of order.
+        let fragB = FountainSSEEnvelope(
+            ev: .message,
+            seq: 1,
+            frag: .init(i: 1, n: 2),
+            data: "lo"
+        )
+        let fragA = FountainSSEEnvelope(
+            ev: .message,
+            seq: 1,
+            frag: .init(i: 0, n: 2),
+            data: "Hel"
+        )
+        let fragBData = try fragB.encodeJSON()
+        let fragAData = try fragA.encodeJSON()
+
+        try await dispatcher.receiveFlex(seq2Data)
+        try await dispatcher.receiveSysEx8(fragBData)
+        try await dispatcher.receiveSysEx8(fragAData)
+
+        var iterator = dispatcher.events.makeAsyncIterator()
+        let first = await iterator.next()
+        XCTAssertEqual(first?.seq, 1)
+        XCTAssertEqual(first?.data, "Hello")
+
+        let second = await iterator.next()
+        XCTAssertEqual(second?.seq, 2)
+        XCTAssertEqual(second?.data, "World")
+    }
+}
+


### PR DESCRIPTION
## Summary
- assemble Flex and SysEx8 fragments into FountainSSEEnvelope
- stream envelopes in sequence order via async dispatcher
- test out-of-order delivery and fragment reassembly

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a722d994908333b62f86ed25948139