### PR TITLE
Add SSE reliability tracking with metrics and tests

### DIFF
--- a/Sources/MIDI/SSE/FountainSSEReliability.swift
+++ b/Sources/MIDI/SSE/FountainSSEReliability.swift
@@ -1,4 +1,104 @@
-// Placeholder for fountain SSE reliability components.
-public struct FountainSSEReliability {
-    public init() {}
+import Foundation
+
+// Refs: teatro-root
+
+/// Reliability helper tracking ACK/NACK state with a retransmit ring buffer
+/// and receive window. Designed for MIDI-based SSE transport.
+public actor FountainSSEReliability {
+
+    /// Hooks for observing reliability metrics.
+    /// Each closure is invoked on the actor's isolated context.
+    public struct MetricsHooks: Sendable {
+        public var onRTT: (@Sendable (TimeInterval) async -> Void)?
+        public var onLoss: (@Sendable (UInt64) async -> Void)?
+        public var onWindowDepth: (@Sendable (Int) async -> Void)?
+
+        public init(
+            onRTT: (@Sendable (TimeInterval) async -> Void)? = nil,
+            onLoss: (@Sendable (UInt64) async -> Void)? = nil,
+            onWindowDepth: (@Sendable (Int) async -> Void)? = nil
+        ) {
+            self.onRTT = onRTT
+            self.onLoss = onLoss
+            self.onWindowDepth = onWindowDepth
+        }
+    }
+
+    private struct Pending: Sendable {
+        var env: FountainSSEEnvelope
+        var timestamp: Date
+    }
+
+    /// Sent envelopes awaiting ACK.
+    private var pending: [UInt64: Pending] = [:]
+
+    /// Max number of outstanding envelopes to keep in the ring buffer.
+    private let capacity: Int
+
+    // Receive window tracking.
+    private var recvBase: UInt64 = 0
+    private var received: Set<UInt64> = []
+
+    private var hooks: MetricsHooks
+
+    public init(windowSize: Int = 32, hooks: MetricsHooks = .init()) {
+        self.capacity = windowSize
+        self.hooks = hooks
+    }
+
+    /// Register a sent envelope for tracking.
+    @discardableResult
+    public func sent(_ env: FountainSSEEnvelope, at date: Date = Date()) async -> UInt64 {
+        pending[env.seq] = Pending(env: env, timestamp: date)
+        trim()
+        await hooks.onWindowDepth?(pending.count)
+        return env.seq
+    }
+
+    /// Process an ACK for a sequence number.
+    @discardableResult
+    public func ack(_ seq: UInt64, at date: Date = Date()) async -> FountainSSEEnvelope? {
+        guard let entry = pending.removeValue(forKey: seq) else { return nil }
+        await hooks.onWindowDepth?(pending.count)
+        await hooks.onRTT?(date.timeIntervalSince(entry.timestamp))
+        return entry.env
+    }
+
+    /// Process a NACK for a sequence number and return the payload to retransmit.
+    public func nack(_ seq: UInt64) async -> FountainSSEEnvelope? {
+        guard let entry = pending[seq] else { return nil }
+        await hooks.onLoss?(seq)
+        return entry.env
+    }
+
+    /// Update receiver state for an incoming sequence number. Returns ACK and any NACKs.
+    public func receive(_ seq: UInt64) -> (ack: UInt64, nacks: [UInt64]) {
+        if recvBase == 0 { recvBase = seq }
+
+        var nacks: [UInt64] = []
+        if seq > recvBase {
+            for missing in recvBase..<seq {
+                if !received.contains(missing) {
+                    nacks.append(missing)
+                }
+            }
+        }
+
+        received.insert(seq)
+        while received.contains(recvBase) {
+            received.remove(recvBase)
+            recvBase &+= 1
+        }
+
+        return (ack: seq, nacks: nacks)
+    }
+
+    private func trim() {
+        while pending.count > capacity {
+            if let oldest = pending.keys.sorted().first {
+                pending.removeValue(forKey: oldest)
+            }
+        }
+    }
 }
+

--- a/Tests/MIDITests/FountainSSEReliabilityTests.swift
+++ b/Tests/MIDITests/FountainSSEReliabilityTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Teatro
+
+// Refs: teatro-root
+
+final class FountainSSEReliabilityTests: XCTestCase {
+    func testRetransmissionOnLoss() async throws {
+        let store = MetricsStore()
+
+        let sender = FountainSSEReliability(
+            windowSize: 8,
+            hooks: .init(
+                onRTT: { await store.addRTT($0) },
+                onLoss: { await store.addLoss($0) },
+                onWindowDepth: { await store.addDepth($0) }
+            )
+        )
+
+        let receiver = FountainSSEReliability(windowSize: 8)
+
+        let env1 = FountainSSEEnvelope(ev: .message, seq: 1, data: "one")
+        let env2 = FountainSSEEnvelope(ev: .message, seq: 2, data: "two")
+        let env3 = FountainSSEEnvelope(ev: .message, seq: 3, data: "three")
+
+        await sender.sent(env1, at: Date(timeIntervalSince1970: 0))
+        await sender.sent(env2, at: Date(timeIntervalSince1970: 0))
+        await sender.sent(env3, at: Date(timeIntervalSince1970: 0))
+
+        // Deliver seq1
+        let r1 = await receiver.receive(env1.seq)
+        XCTAssertEqual(r1.ack, 1)
+        XCTAssertTrue(r1.nacks.isEmpty)
+        await sender.ack(r1.ack, at: Date(timeIntervalSince1970: 1))
+
+        // Drop seq2
+
+        // Deliver seq3 causing receiver to nack seq2
+        let r3 = await receiver.receive(env3.seq)
+        XCTAssertEqual(r3.ack, 3)
+        XCTAssertEqual(r3.nacks, [2])
+        await sender.ack(r3.ack, at: Date(timeIntervalSince1970: 1))
+
+        // Sender retransmits seq2
+        guard let resend = await sender.nack(2) else {
+            return XCTFail("Expected retransmission for seq2")
+        }
+        let r2 = await receiver.receive(resend.seq)
+        XCTAssertEqual(r2.ack, 2)
+        XCTAssertTrue(r2.nacks.isEmpty)
+        await sender.ack(r2.ack, at: Date(timeIntervalSince1970: 2))
+
+        let rtts = await store.rtts
+        let losses = await store.losses
+        let depths = await store.depths
+
+        XCTAssertEqual(losses, [2])
+        XCTAssertEqual(depths.last, 0)
+        XCTAssertEqual(rtts.first ?? -1, 1.0, accuracy: 0.0001)
+    }
+}
+
+private actor MetricsStore {
+    var rtts: [TimeInterval] = []
+    var losses: [UInt64] = []
+    var depths: [Int] = []
+
+    func addRTT(_ v: TimeInterval) { rtts.append(v) }
+    func addLoss(_ v: UInt64) { losses.append(v) }
+    func addDepth(_ v: Int) { depths.append(v) }
+}
+


### PR DESCRIPTION
## Summary
- implement `FountainSSEReliability` actor with retransmit ring buffer and receive window
- add metrics hooks for round trip time, loss, and window depth
- test retransmission logic under packet loss

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a726f4688083339cfef04a1d48d74a