### PR TITLE
Implement JR timing utilities and scheduler

### DIFF
--- a/Sources/MIDI/SSE/FountainSSETiming.swift
+++ b/Sources/MIDI/SSE/FountainSSETiming.swift
@@ -1,4 +1,58 @@
-// Placeholder for fountain SSE timing utilities.
+import Foundation
+
+// Refs: teatro-root
+
+/// JR timestamp helpers and jitter-buffered playout scheduling.
 public struct FountainSSETiming {
+    /// JR clock ticks per second (10.22 fixed-point format).
+    public static let ticksPerSecond: Double = 4_194_304
+    /// Milliseconds represented by a single JR tick.
+    public static let msPerTick: Double = 1000.0 / ticksPerSecond
+    public static let secondsPerTick: Double = 1.0 / ticksPerSecond
+
     public init() {}
+
+    /// Convert a JR timestamp delta to milliseconds.
+    public static func milliseconds(fromJRTimestamp ts: UInt32) -> Double {
+        Double(ts) * msPerTick
+    }
+
+    /// Convert milliseconds to JR timestamp ticks.
+    public static func jrTimestamp(fromMilliseconds ms: Double) -> UInt32 {
+        UInt32(ms / msPerTick)
+    }
+
+    /// Compute playout time with a jitter buffer. Returns the scheduled `Date`
+    /// and whether the packet arrived too late to meet `targetPlayoutMs`.
+    /// - Parameters:
+    ///   - jrTimestamp: Optional JR timestamp of the packet relative to `nowJR`.
+    ///   - nowJR: Current JR clock reading when the packet was received.
+    ///   - arrival: Local arrival time for reference.
+    ///   - targetPlayoutMs: Desired playout delay in milliseconds.
+    public static func schedule(
+        jrTimestamp: UInt32?,
+        nowJR: UInt32,
+        arrival: Date = Date(),
+        targetPlayoutMs: Double
+    ) -> (playout: Date, late: Bool) {
+        if let jr = jrTimestamp {
+            let diffTicks = Int64(UInt64(jr) &- UInt64(nowJR))
+            let deltaMs = Double(diffTicks) * msPerTick
+            if deltaMs < targetPlayoutMs {
+                let rounded = ceil(targetPlayoutMs)
+                let time = arrival.addingTimeInterval(rounded / 1000)
+                return (time, true)
+            } else {
+                let rounded = ceil(deltaMs)
+                let time = arrival.addingTimeInterval(rounded / 1000)
+                return (time, false)
+            }
+        } else {
+            let rounded = ceil(targetPlayoutMs)
+            let time = arrival.addingTimeInterval(rounded / 1000)
+            return (time, false)
+        }
+    }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/MIDITests/FountainSSETimingTests.swift
+++ b/Tests/MIDITests/FountainSSETimingTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Teatro
+
+// Refs: teatro-root
+
+final class FountainSSETimingTests: XCTestCase {
+    func testScheduleRounding() {
+        let now = Date()
+        let nowJR: UInt32 = 0
+        let futureJR = FountainSSETiming.jrTimestamp(fromMilliseconds: 10.4)
+        let (playout, late) = FountainSSETiming.schedule(
+            jrTimestamp: futureJR,
+            nowJR: nowJR,
+            arrival: now,
+            targetPlayoutMs: 2
+        )
+        XCTAssertFalse(late)
+        let deltaMs = playout.timeIntervalSince(now) * 1000
+        XCTAssertEqual(deltaMs, 11, accuracy: 0.001)
+    }
+
+    func testLatePacketDetection() {
+        let now = Date()
+        let nowJR: UInt32 = 0
+        let nearJR = FountainSSETiming.jrTimestamp(fromMilliseconds: 1)
+        let (playout, late) = FountainSSETiming.schedule(
+            jrTimestamp: nearJR,
+            nowJR: nowJR,
+            arrival: now,
+            targetPlayoutMs: 3
+        )
+        XCTAssertTrue(late)
+        let deltaMs = playout.timeIntervalSince(now) * 1000
+        XCTAssertEqual(deltaMs, 3, accuracy: 0.001)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add JR timestamp conversions and jitter-buffered playout scheduler
- honor `targetPlayoutMs` with fallback when JR is missing
- test schedule rounding and late packet detection

## Testing
- `swift test`
- `swift test --filter FountainSSETimingTests`


------
https://chatgpt.com/codex/tasks/task_b_68a728c12f5483338b894f29665425e1