### PR TITLE
Add Fountain SSE MIDI-CI profile and property exchange

### DIFF
--- a/Sources/MIDI/CI/FountainSSEProfile.swift
+++ b/Sources/MIDI/CI/FountainSSEProfile.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// Refs: teatro-root
+
+/// MIDI-CI profile identifiers and helpers for Fountain SSE transport.
+public enum FountainSSEProfile {
+    /// Identifier string used during profile negotiation.
+    public static let id = "fountain.sse"
+
+    /// Build an enable profile negotiation message.
+    public static func enable(deviceID: UInt8, functionBlock: UInt8 = 0) -> MIDICIProfileNegotiation {
+        MIDICIProfileNegotiation(
+            deviceID: deviceID,
+            functionBlock: functionBlock,
+            operation: .enable,
+            profile: id
+        )
+    }
+
+    /// Build a disable profile negotiation message.
+    public static func disable(deviceID: UInt8, functionBlock: UInt8 = 0) -> MIDICIProfileNegotiation {
+        MIDICIProfileNegotiation(
+            deviceID: deviceID,
+            functionBlock: functionBlock,
+            operation: .disable,
+            profile: id
+        )
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/MIDI/CI/FountainSSEProperties.swift
+++ b/Sources/MIDI/CI/FountainSSEProperties.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// Refs: teatro-root
+
+/// Property identifiers for Fountain SSE profile exchange.
+public enum FountainSSEProperties {
+    /// Property describing the endpoint URL for SSE over MIDI.
+    public static let endpointURL = "fountain.sse.endpoint"
+
+    /// Encodes the endpoint URL string into property value data.
+    public static func encodeEndpoint(_ url: String) -> Data {
+        Data(url.utf8)
+    }
+
+    /// Decodes endpoint URL data from a property exchange.
+    public static func decodeEndpoint(_ data: Data) -> String? {
+        String(data: data, encoding: .utf8)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/MIDI/MIDICIDispatcher.swift
+++ b/Sources/MIDI/MIDICIDispatcher.swift
@@ -1,7 +1,12 @@
 import Foundation
 
+// Refs: teatro-root
+
 /// Routes SysEx events through the MIDI-CI parser.
 public struct MIDICIDispatcher {
+    /// Set of currently enabled profile identifiers.
+    nonisolated(unsafe) public static var enabledProfiles: Set<String> = []
+
     /// Attempts to interpret a parsed MIDI event as a MIDI-CI message.
     /// - Parameter event: A `MidiEventProtocol` value, typically produced by `UMPParser`.
     /// - Returns: A `MIDICIMessage` if the event is a valid MIDI-CI SysEx packet.
@@ -9,6 +14,15 @@ public struct MIDICIDispatcher {
         guard event.type == .sysEx, let raw = event.rawData else { return nil }
         let bytes = [UInt8](raw)
         guard bytes.first == 0xF0, bytes.last == 0xF7 else { return nil }
-        return MIDICI.parse(sysEx: raw)
+        guard let message = MIDICI.parse(sysEx: raw) else { return nil }
+        if case .profile(let negotiation) = message {
+            switch negotiation.operation {
+            case .enable:
+                enabledProfiles.insert(negotiation.profile)
+            case .disable:
+                enabledProfiles.remove(negotiation.profile)
+            }
+        }
+        return message
     }
 }

--- a/Tests/MIDITests/MIDICIFountainSSETests.swift
+++ b/Tests/MIDITests/MIDICIFountainSSETests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Teatro
+
+final class MIDICIFountainSSETests: XCTestCase {
+    final class MockPeer {
+        var enabledProfiles: Set<String> = []
+        var properties: [String: Data] = [:]
+
+        func receive(_ message: MIDICIMessage) {
+            switch message {
+            case .profile(let negotiation):
+                if negotiation.operation == .enable {
+                    enabledProfiles.insert(negotiation.profile)
+                } else {
+                    enabledProfiles.remove(negotiation.profile)
+                }
+            case .property(let exchange):
+                properties[exchange.property] = exchange.value
+            case .discovery:
+                break
+            }
+        }
+    }
+
+    private func send(_ message: MIDICIMessage, to peer: MockPeer) throws {
+        let sysEx = MIDICI.serialize(message)
+        let event = SysExEvent(timestamp: 0, data: sysEx, group: 0)
+        let words = UMPEncoder.encodeEvent(event, defaultGroup: 0)
+        var data = Data()
+        for word in words {
+            var be = word.bigEndian
+            withUnsafeBytes(of: &be) { data.append(contentsOf: $0) }
+        }
+        let parsed = try UMPParser.parse(data: data)
+        guard let parsedEvent = parsed.first else { return }
+        if let msg = MIDICIDispatcher.dispatch(event: parsedEvent) {
+            peer.receive(msg)
+        }
+    }
+
+    func testEnableDisableAndPropertyRoundTrip() throws {
+        MIDICIDispatcher.enabledProfiles.removeAll()
+        let peer = MockPeer()
+        try send(.profile(FountainSSEProfile.enable(deviceID: 0x01)), to: peer)
+        XCTAssertTrue(peer.enabledProfiles.contains(FountainSSEProfile.id))
+        XCTAssertTrue(MIDICIDispatcher.enabledProfiles.contains(FountainSSEProfile.id))
+
+        let url = "wss://example.com"
+        let value = FountainSSEProperties.encodeEndpoint(url)
+        let prop = MIDICIPropertyExchange(deviceID: 0x01, property: FountainSSEProperties.endpointURL, value: value)
+        try send(.property(prop), to: peer)
+        XCTAssertEqual(peer.properties[FountainSSEProperties.endpointURL], value)
+
+        try send(.profile(FountainSSEProfile.disable(deviceID: 0x01)), to: peer)
+        XCTAssertFalse(peer.enabledProfiles.contains(FountainSSEProfile.id))
+        XCTAssertFalse(MIDICIDispatcher.enabledProfiles.contains(FountainSSEProfile.id))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- introduce Fountain SSE MIDI-CI profile and property schema
- extend MIDI-CI message parsing and dispatcher profile tracking
- add tests covering profile enable/disable and property round-trip

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a72bd0d2188333827eb41c20f9c087