### PR TITLE
Add streaming overlays and controls to TeatroPlayerView

### DIFF
--- a/Sources/ViewCore/Streaming/StreamStatusView.swift
+++ b/Sources/ViewCore/Streaming/StreamStatusView.swift
@@ -1,4 +1,50 @@
-// Placeholder for stream status view.
-public struct StreamStatusView {
-    public init() {}
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Visualizes basic stream metrics such as connection state, ACK/NACK counters
+/// and latency. These values are placeholders for now but provide the
+/// foundation for wiring real telemetry later on.
+@available(macOS 13, *)
+public struct StreamStatusView: View {
+    public var connected: Bool
+    public var acks: Int
+    public var nacks: Int
+    public var rtt: Double
+    public var window: Int
+    public var loss: Double
+
+    public init(
+        connected: Bool = false,
+        acks: Int = 0,
+        nacks: Int = 0,
+        rtt: Double = 0,
+        window: Int = 0,
+        loss: Double = 0
+    ) {
+        self.connected = connected
+        self.acks = acks
+        self.nacks = nacks
+        self.rtt = rtt
+        self.window = window
+        self.loss = loss
+    }
+
+    public var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(connected ? Color.green : Color.red)
+                .frame(width: 10, height: 10)
+            Text("ACK \(acks)")
+            Text("NACK \(nacks)")
+            Text(String(format: "RTT %.0fms", rtt))
+            Text("WIN \(window)")
+            Text(String(format: "LOSS %.1f%%", loss))
+        }
+        .font(.caption.monospaced())
+        .padding(4)
+        .background(Color.black.opacity(0.1))
+        .cornerRadius(4)
+    }
 }
+#endif
+

--- a/Sources/ViewCore/Streaming/TokenStreamView.swift
+++ b/Sources/ViewCore/Streaming/TokenStreamView.swift
@@ -1,4 +1,48 @@
-// Placeholder for token stream view.
-public struct TokenStreamView {
-    public init() {}
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Renders a stream of SSE tokens. When `showBeatGrid` is enabled the view
+/// overlays simple beat markers behind the tokens. This is intentionally
+/// lightweight and serves as the foundation for richer timing alignment.
+@available(macOS 13, *)
+public struct TokenStreamView: View {
+    /// Tokens to display in the order they were received.
+    public var tokens: [String]
+    /// Enables a rudimentary beat grid behind the tokens.
+    public var showBeatGrid: Bool
+
+    /// Creates a new token stream view.
+    /// - Parameters:
+    ///   - tokens: The textual tokens to render.
+    ///   - showBeatGrid: Whether to overlay beat markers.
+    public init(tokens: [String] = [], showBeatGrid: Bool = false) {
+        self.tokens = tokens
+        self.showBeatGrid = showBeatGrid
+    }
+
+    public var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            if showBeatGrid {
+                HStack(spacing: 4) {
+                    ForEach(tokens.indices, id: \.self) { _ in
+                        VStack {
+                            Rectangle()
+                                .fill(Color.gray.opacity(0.3))
+                                .frame(width: 1, height: 20)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            HStack(spacing: 4) {
+                ForEach(Array(tokens.enumerated()), id: \.0) { _, token in
+                    Text(token)
+                        .font(.system(size: 12, weight: .regular, design: .monospaced))
+                }
+            }
+        }
+        .padding(4)
+    }
 }
+#endif
+


### PR DESCRIPTION
## Summary
- implement TokenStreamView that renders SSE tokens with optional beat-grid
- implement StreamStatusView exposing connection metrics
- overlay streaming views and record/replay controls in TeatroPlayerView

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a72e18beb88333bc9da8684d21dc40