### PR TITLE
Add stream preview controller and watch endpoint

### DIFF
--- a/Docs/RenderAPI.md
+++ b/Docs/RenderAPI.md
@@ -38,3 +38,10 @@ struct Preview: View {
 }
 ```
 
+### Streaming Preview
+
+`StreamPreviewController` connects Universal MIDI Packet streams to
+`FountainSSEEnvelope` events and forwards the resulting tokens to the
+`TeatroPlayerView` overlays. The accompanying Render API exposes a `/watch`
+endpoint that mirrors the GUI preview by emitting `text/event-stream` updates.
+

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
             targets: ["Teatro"]
         ),
         .library(name: "TeatroRenderAPI", targets: ["TeatroRenderAPI"]),
+        .library(name: "RenderAPI", targets: ["RenderAPI"]),
         .executable(name: "RenderCLI", targets: ["RenderCLI"]),
         .executable(name: "TeatroSamplerDemo", targets: ["TeatroSamplerDemo"]),
         .executable(name: "teatro-play", targets: ["TeatroPlay"])
@@ -25,7 +26,7 @@ let package = Package(
             name: "Teatro",
             dependencies: ["CCsound", "CFluidSynth", .product(name: "MIDI2", package: "MIDI2"), "SwiftCBOR"],
             path: "Sources",
-            exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md", "TeatroRenderAPI"],
+            exclude: ["CLI", "TeatroSamplerDemo", "TeatroPlay", "CCsound", "CFluidSynth", "MIDI/Teatro-Codex-Plan.md", "TeatroRenderAPI", "RenderAPI"],
             resources: [
                 .process("Audio/Resources")
             ],
@@ -79,11 +80,16 @@ let package = Package(
             dependencies: ["Teatro"],
             path: "Sources/TeatroRenderAPI"
         ),
+        .target(
+            name: "RenderAPI",
+            dependencies: ["Teatro", "TeatroRenderAPI"],
+            path: "Sources/RenderAPI"
+        ),
         .testTarget(
             name: "TeatroTests",
             dependencies: ["Teatro"],
             path: "Tests",
-            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests", "SamplerTests", "CLI", "TeatroRenderAPITests"],
+            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests", "SamplerTests", "CLI", "TeatroRenderAPITests", "RenderAPITests"],
             resources: [
                 .process("Fixtures")
             ]
@@ -120,6 +126,11 @@ let package = Package(
             resources: [
                 .process("__snapshots__")
             ]
+        ),
+        .testTarget(
+            name: "RenderAPITests",
+            dependencies: ["RenderAPI"],
+            path: "Tests/RenderAPITests"
         ),
         .target(
             name: "CCsound",

--- a/Sources/RenderAPI/StreamPreviewController.swift
+++ b/Sources/RenderAPI/StreamPreviewController.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Teatro
+
+/// Bridges incoming Universal MIDI Packet (UMP) fragments into `FountainSSEEnvelope`
+/// events and exposes the reassembled token stream for preview purposes.
+public actor StreamPreviewController {
+    private let dispatcher = FountainSSEDispatcher()
+    private let reliability = FountainSSEReliability()
+    private var tokenBuffer: [String] = []
+
+    public init() {
+        // Consume dispatcher events and accumulate tokens.
+        Task {
+            for await env in dispatcher.events {
+                await self.handle(env)
+            }
+        }
+    }
+
+    /// Ingest a UMP flex data fragment carrying an SSE envelope.
+    public func ingestFlex(_ data: Data) async throws {
+        try await dispatcher.receiveFlex(data)
+    }
+
+    /// Ingest a UMP SysEx8 fragment carrying an SSE envelope.
+    public func ingestSysEx8(_ data: Data) async throws {
+        try await dispatcher.receiveSysEx8(data)
+    }
+
+    private func handle(_ env: FountainSSEEnvelope) async {
+        if env.ev == .message, let token = env.data {
+            tokenBuffer.append(token)
+        } else if env.ev == .ctrl {
+            // Simple reliability hook for ACK messages.
+            if let payload = env.data?.data(using: .utf8),
+               let json = try? JSONSerialization.jsonObject(with: payload) as? [String: Any],
+               let ack = json["ack"] as? UInt64 {
+                await self.reliability.ack(ack)
+            }
+        }
+        _ = await reliability.receive(env.seq)
+    }
+
+    /// Current list of received tokens in order of arrival.
+    public func tokens() -> [String] {
+        tokenBuffer
+    }
+}
+
+#if canImport(SwiftUI) && canImport(WebKit) && os(macOS)
+import SwiftUI
+import TeatroRenderAPI
+
+/// SwiftUI helper that overlays streaming diagnostics onto the `TeatroPlayerView`.
+public extension StreamPreviewController {
+    @MainActor
+    func playerView(svg: Data, timeline: Data? = nil) -> some View {
+        TeatroPlayerView(svg: svg, timeline: timeline)
+            .overlay(alignment: .topLeading) {
+                VStack {
+                    TokenStreamView(tokens: tokenBuffer)
+                    Spacer()
+                    StreamStatusView()
+                }
+                .padding()
+            }
+    }
+}
+#endif

--- a/Tests/RenderAPITests/StreamPreviewControllerTests.swift
+++ b/Tests/RenderAPITests/StreamPreviewControllerTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import RenderAPI
+import Teatro
+
+/// Integration test verifying that UMP fragments are translated into a token stream.
+final class StreamPreviewControllerTests: XCTestCase {
+    func testTokenAccumulation() async throws {
+        let controller = StreamPreviewController()
+        let env1 = FountainSSEEnvelope(ev: .message, seq: 1, data: "Hello")
+        let env2 = FountainSSEEnvelope(ev: .message, seq: 2, data: "World")
+        try await controller.ingestFlex(env1.encodeJSON())
+        try await controller.ingestFlex(env2.encodeJSON())
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let tokens = await controller.tokens()
+        XCTAssertEqual(tokens, ["Hello", "World"])
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,6 +25,22 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/RenderResponse"
+  /watch:
+    post:
+      summary: Stream preview updates for a Teatro view
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RenderRequest"
+      responses:
+        "200":
+          description: Preview stream delivered as Server-Sent Events
+          content:
+            text/event-stream:
+              schema:
+                type: string
 components:
   schemas:
     RenderRequest:


### PR DESCRIPTION
## Summary
- build StreamPreviewController to pipe UMP fragments into SSE token stream and optional SwiftUI previews
- expose `/watch` SSE preview endpoint in openapi
- document streaming preview controller and add headless integration test

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a72fa25d488333a13ee81f5eedd305