### PR TITLE
Add RTP-MIDI streaming flags to RenderCLI

### DIFF
--- a/Sources/CLI/RenderCLI.docc/render-cli.md
+++ b/Sources/CLI/RenderCLI.docc/render-cli.md
@@ -5,7 +5,7 @@
 Render Teatro views from scripts, scores, and storyboards.
 
 ```
-render-cli [<positional-input>] [--input=<input>] [--format=<format>] [--output=<output>] [--watch] [--force-format] [--width=<width>] [--height=<height>] [--version] [--help]
+render-cli [<positional-input>] [--input=<input>] [--format=<format>] [--output=<output>] [--watch] [--force-format] [--midi1-bridge] [--watch-rtpmidi] [--sse-group=<sse-group>] [--save-ump=<save-ump>] [--replay-ump=<replay-ump>] [--width=<width>] [--height=<height>] [--version] [--help]
 ```
 
 **positional-input:**
@@ -37,6 +37,26 @@ render-cli [<positional-input>] [--input=<input>] [--format=<format>] [--output=
 
 *Ignore mismatched output extension and format*
 
+
+**--midi1-bridge:**
+
+*Bridge UMP input to MIDI 1.0 byte stream for legacy devices*
+
+**--watch-rtpmidi:**
+
+*Subscribe to RTP-MIDI UMP packets and forward them to stdout*
+
+**--sse-group=\<sse-group\>:**
+
+*Filter incoming UMP stream by group*
+
+**--save-ump=\<save-ump\>:**
+
+*Persist received UMP packets to the given file*
+
+**--replay-ump=\<replay-ump\>:**
+
+*Replay UMP packets from file*
 
 **--width=\<width\>:**
 


### PR DESCRIPTION
## Summary
- add `--watch-rtpmidi`, `--sse-group`, `--save-ump`, and `--replay-ump` options
- allow piping RTP-MIDI data through MIDI1 bridge to `teatro-play`
- document and test new CLI flags

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a731e27cfc83339eb7d24ea907442b