### PR TITLE
Add SSE reliability and scheduling tests

### DIFF
--- a/Tests/MIDITests/FountainSSEDispatcherTests.swift
+++ b/Tests/MIDITests/FountainSSEDispatcherTests.swift
@@ -40,5 +40,26 @@ final class FountainSSEDispatcherTests: XCTestCase {
         XCTAssertEqual(second?.seq, 2)
         XCTAssertEqual(second?.data, "World")
     }
+
+    func testInOrderFragmentReassembly() async throws {
+        let dispatcher = FountainSSEDispatcher()
+        let fragA = FountainSSEEnvelope(
+            ev: .message,
+            seq: 1,
+            frag: .init(i: 0, n: 2),
+            data: "Hel"
+        )
+        let fragB = FountainSSEEnvelope(
+            ev: .message,
+            seq: 1,
+            frag: .init(i: 1, n: 2),
+            data: "lo"
+        )
+        try await dispatcher.receiveSysEx8(fragA.encodeJSON())
+        try await dispatcher.receiveSysEx8(fragB.encodeJSON())
+        var iterator = dispatcher.events.makeAsyncIterator()
+        let assembled = await iterator.next()
+        XCTAssertEqual(assembled?.data, "Hello")
+    }
 }
 

--- a/Tests/MIDITests/FountainSSEEnvelopeTests.swift
+++ b/Tests/MIDITests/FountainSSEEnvelopeTests.swift
@@ -36,4 +36,11 @@ final class FountainSSEEnvelopeTests: XCTestCase {
         """.data(using: .utf8)!
         XCTAssertThrowsError(try FountainSSEEnvelope.decodeJSON(json))
     }
+
+    func testInvalidVersionRejected() throws {
+        let json = """
+        {"v":2,"ev":"message","seq":1}
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try FountainSSEEnvelope.decodeJSON(json))
+    }
 }

--- a/Tests/MIDITests/FountainSSELossIntegrationTests.swift
+++ b/Tests/MIDITests/FountainSSELossIntegrationTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Teatro
+
+// Refs: teatro-root
+
+final class FountainSSELossIntegrationTests: XCTestCase {
+    func testReliabilityRecoversFromLoss() async throws {
+        let dispatcher = FountainSSEDispatcher()
+        let sender = FountainSSEReliability(windowSize: 32)
+        let receiver = FountainSSEReliability(windowSize: 32)
+
+        let total = 100
+        let losses: Set<Int> = [5, 23, 67, 89] // ~4% loss
+        let reference = (1...total).map(String.init).joined(separator: " ")
+
+        func deliver(_ env: FountainSSEEnvelope) async throws {
+            let result = await receiver.receive(env.seq)
+            try await dispatcher.receiveFlex(env.encodeJSON())
+            await sender.ack(result.ack)
+            for n in result.nacks {
+                if let resend = await sender.nack(n) {
+                    try await deliver(resend)
+                }
+            }
+        }
+
+        for seq in 1...total {
+            let env = FountainSSEEnvelope(ev: .message, seq: UInt64(seq), data: "\(seq)")
+            await sender.sent(env)
+            if !losses.contains(seq) {
+                try await deliver(env)
+            }
+        }
+
+        var iterator = dispatcher.events.makeAsyncIterator()
+        var pieces: [String] = []
+        for _ in 1...total {
+            if let env = await iterator.next() {
+                pieces.append(env.data ?? "")
+            }
+        }
+        let result = pieces.joined(separator: " ")
+        XCTAssertEqual(result, reference)
+    }
+}
+

--- a/Tests/MIDITests/FountainSSEReliabilityTests.swift
+++ b/Tests/MIDITests/FountainSSEReliabilityTests.swift
@@ -57,6 +57,17 @@ final class FountainSSEReliabilityTests: XCTestCase {
         XCTAssertEqual(depths.last, 0)
         XCTAssertEqual(rtts.first ?? -1, 1.0, accuracy: 0.0001)
     }
+
+    func testReceiveWindowNacksRange() async {
+        let reliability = FountainSSEReliability(windowSize: 8)
+        let r1 = await reliability.receive(1)
+        XCTAssertEqual(r1.ack, 1)
+        XCTAssertTrue(r1.nacks.isEmpty)
+
+        let r4 = await reliability.receive(4)
+        XCTAssertEqual(r4.ack, 4)
+        XCTAssertEqual(r4.nacks, [2, 3])
+    }
 }
 
 private actor MetricsStore {

--- a/Tests/MIDITests/FountainSSETimingTests.swift
+++ b/Tests/MIDITests/FountainSSETimingTests.swift
@@ -33,5 +33,18 @@ final class FountainSSETimingTests: XCTestCase {
         let deltaMs = playout.timeIntervalSince(now) * 1000
         XCTAssertEqual(deltaMs, 3, accuracy: 0.001)
     }
+
+    func testScheduleWithoutTimestamp() {
+        let now = Date()
+        let (playout, late) = FountainSSETiming.schedule(
+            jrTimestamp: nil,
+            nowJR: 0,
+            arrival: now,
+            targetPlayoutMs: 5
+        )
+        XCTAssertFalse(late)
+        let deltaMs = playout.timeIntervalSince(now) * 1000
+        XCTAssertEqual(deltaMs, 5, accuracy: 0.001)
+    }
 }
 


### PR DESCRIPTION
## Summary
- add unit tests for SSE envelope version handling, reliability NACK windows, SysEx8 reassembly, and jitter-buffer scheduling
- simulate 4% packet loss to ensure reliability recovers full text stream

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a7342f82b48333b12c2366acf2fa6f