### PR TITLE
docs: document SSE-over-MIDI2 streaming

### DIFF
--- a/Docs/Chapters/11_TeatroPlayer.md
+++ b/Docs/Chapters/11_TeatroPlayer.md
@@ -23,6 +23,10 @@ let player = TeatroPlayerView(storyboard: storyboard, midi: melody)
 Pass `comments: [String]` when constructing frames to display semantic notes
 overlayed during playback.
 
+### Streaming overlays
+
+`TeatroPlayerView` can subscribe to **SSE envelopes** delivered over MIDI 2.0. Tokens from the stream render as live overlay views while status lights expose group activity, round‑trip time, and retransmission counts.
+
 ### Enabling audio
 
 `TeatroPlayerView` drives audio via `TeatroSampler`, a cross-platform actor-based

--- a/Docs/Chapters/12_SSE_Over_MIDI2.md
+++ b/Docs/Chapters/12_SSE_Over_MIDI2.md
@@ -1,0 +1,25 @@
+## 12. SSE over MIDI 2.0
+
+_Streaming server‑sent events with MIDI 2.0 Flex Data and SysEx8._
+
+### Overview
+
+Teatro can consume Server‑Sent Events (SSE) that are transported inside Universal MIDI Packets (UMP). Small envelopes travel in **Flex Data** packets while larger payloads use **SysEx8**. Each envelope follows the FountainAI JSON schema and maps directly onto UMP groups.
+
+See `assets/sse-demo.ump` for a minimal capture.
+
+### Timing
+
+Every SSE envelope may carry a JR Timestamp. The player aligns frames using that timestamp and a small jitter buffer so live streams remain beat‑synchronized even across RTP‑MIDI links.
+
+### Reliability
+
+Streams negotiate a lightweight window with MIDI‑CI property exchange and acknowledge received envelopes. A retransmit buffer and NACK tracking close short gaps without stalling the pipeline.
+
+### GUI
+
+`TeatroPlayerView` surfaces stream status overlays for group activity, RTT estimates, and retransmission counts. Tokens emitted by the stream appear in dedicated subviews that scroll in time with the score.
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ The command above reads a UMP file, translates it to MIDI 1.0 bytes, and writes
 the result to standard output (or the file specified with `--output`).
 `MIDI1Bridge.midi1ToUMP(_:)` performs the inverse conversion when needed.
 
+## SSE over MIDI 2.0
+
+Teatro can ingest **Server-Sent Events** streamed inside MIDI 2.0 UMP. Flex Data carries short envelopes while SysEx8 handles larger payloads. Streams honor JR Timestamps with a small jitter buffer so live tokens stay beat‑aligned. The player shows reliability stats and tokens in real time. A minimal capture lives at `assets/sse-demo.ump`.
+
 ### Command-line Playback
 
 Pipe bridged MIDI data into the `teatro-play` utility to hear it through
@@ -57,7 +61,8 @@ The long-form documentation lives under `Docs/Chapters`. Start with the timeline
 - [9. Fountain Parser Implementation](Docs/Chapters/09_FountainParserImplementationPlan.md)
 - [10. Storyboard DSL](Docs/Chapters/10_StoryboardDSL.md)
 - [11. TeatroPlayerView Usage](Docs/Chapters/11_TeatroPlayer.md)
-- [15. TeatroSampler](Docs/Chapters/12_TeatroSampler.md)
+- [12. SSE over MIDI 2.0](Docs/Chapters/12_SSE_Over_MIDI2.md)
+- [13. TeatroSampler](Docs/Chapters/12_TeatroSampler.md)
 - [Addendum: Apple Platform Compatibility](Docs/Chapters/Addendum.md)
 
 Historical proposals live in [`Docs/Proposals`](Docs/Proposals).

--- a/TEATRO_GUI_RenderAPI_Blueprint_PR_Checklist.md
+++ b/TEATRO_GUI_RenderAPI_Blueprint_PR_Checklist.md
@@ -17,6 +17,7 @@
 - Keep **Teatro as the only renderer**: no other GUI engines or renderers in downstream repos.
 - Support **headless** (Linux) and **desktop** (macOS) usage through the same Render API.
 - Offer an **embeddable SwiftUI preview view** (`TeatroPlayerView`) that accepts SVG (and later timeline data).
+- Expose **SSE-over-MIDI2 streams** with timing and reliability overlays in the preview player.
 
 ### Non‑Goals
 - Building product‑specific UIs; Teatro stays a rendering/runtime engine.
@@ -242,6 +243,7 @@ Tests/TeatroRenderAPITests/
 - [ ] Wire `Package.swift` products & targets.
 - [ ] Add snapshot tests and API conformance tests.
 - [ ] Add `Docs/RenderAPI.md` and README section.
+- [ ] Document SSE-over-MIDI2 streaming and include demo capture.
 - [ ] Bump version (minor) and update CHANGELOG.
 - [ ] CI green on macOS + Linux.
 - [ ] Tag release `vX.Y.0`.

--- a/assets/sse-demo.ump
+++ b/assets/sse-demo.ump
@@ -1,0 +1,2 @@
+# Sample SSE-over-MIDI2 UMP stream (hex pairs)
+F0 59 00 10 00 00 00 00 7B 22 76 22 3A 31 2C 22 65 76 22 3A 22 6D 65 73 73 61 67 65 22 7D F7


### PR DESCRIPTION
## Summary
- add SSE-over-MIDI2 chapter outlining overview, timing, reliability and GUI overlays
- note streaming overlays in TeatroPlayerView docs and README
- extend GUI Render API checklist with SSE streaming task and add demo UMP capture

## Testing
- `swift test` *(hangs at FountainSSEDispatcherTests.testInOrderFragmentReassembly)*

------
https://chatgpt.com/codex/tasks/task_b_68a7383158048333ae0324d4a48ff964