### PR TITLE
fix: disambiguate SwiftUI streaming views

### DIFF
--- a/Sources/MIDI/SSE/FountainSSEDispatcher.swift
+++ b/Sources/MIDI/SSE/FountainSSEDispatcher.swift
@@ -18,7 +18,7 @@ public actor FountainSSEDispatcher {
     private var ready: [UInt64: FountainSSEEnvelope] = [:]
 
     /// Next expected sequence number.
-    private var nextSeq: UInt64?
+    private var nextSeq: UInt64 = 1
 
     public init() {
         var cont: AsyncStream<FountainSSEEnvelope>.Continuation!
@@ -81,23 +81,18 @@ public actor FountainSSEDispatcher {
     }
 
     private func publishReady() {
-        if nextSeq == nil {
-            nextSeq = ready.keys.min()
-        }
-        while let seq = nextSeq, let env = ready[seq] {
+        while let env = ready[nextSeq] {
             continuation.yield(env)
-            ready.removeValue(forKey: seq)
-            nextSeq = seq &+ 1
+            ready.removeValue(forKey: nextSeq)
+            nextSeq &+= 1
         }
     }
 
     private func updateAndPublish(for seq: UInt64) {
-        if let current = nextSeq {
-            if seq < current { nextSeq = seq }
-            publishReady()
-        } else {
+        if seq < nextSeq {
             nextSeq = seq
         }
+        publishReady()
     }
 }
 

--- a/Sources/ViewCore/Streaming/StreamStatusView.swift
+++ b/Sources/ViewCore/Streaming/StreamStatusView.swift
@@ -30,19 +30,19 @@ public struct StreamStatusView: View {
     }
 
     public var body: some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(connected ? Color.green : Color.red)
+        SwiftUI.HStack(spacing: 8) {
+            SwiftUI.Circle()
+                .fill(connected ? SwiftUI.Color.green : SwiftUI.Color.red)
                 .frame(width: 10, height: 10)
-            Text("ACK \(acks)")
-            Text("NACK \(nacks)")
-            Text(String(format: "RTT %.0fms", rtt))
-            Text("WIN \(window)")
-            Text(String(format: "LOSS %.1f%%", loss))
+            SwiftUI.Text("ACK \(acks)")
+            SwiftUI.Text("NACK \(nacks)")
+            SwiftUI.Text(String(format: "RTT %.0fms", rtt))
+            SwiftUI.Text("WIN \(window)")
+            SwiftUI.Text(String(format: "LOSS %.1f%%", loss))
         }
-        .font(.caption.monospaced())
+        .font(SwiftUI.Font.caption.monospaced())
         .padding(4)
-        .background(Color.black.opacity(0.1))
+        .background(SwiftUI.Color.black.opacity(0.1))
         .cornerRadius(4)
     }
 }

--- a/Sources/ViewCore/Streaming/TokenStreamView.swift
+++ b/Sources/ViewCore/Streaming/TokenStreamView.swift
@@ -21,23 +21,23 @@ public struct TokenStreamView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .bottomLeading) {
+        SwiftUI.ZStack(alignment: .bottomLeading) {
             if showBeatGrid {
-                HStack(spacing: 4) {
-                    ForEach(tokens.indices, id: \.self) { _ in
-                        VStack {
-                            Rectangle()
-                                .fill(Color.gray.opacity(0.3))
+                SwiftUI.HStack(spacing: 4) {
+                    SwiftUI.ForEach(tokens.indices, id: \.self) { _ in
+                        SwiftUI.VStack {
+                            SwiftUI.Rectangle()
+                                .fill(SwiftUI.Color.gray.opacity(0.3))
                                 .frame(width: 1, height: 20)
-                            Spacer()
+                            SwiftUI.Spacer()
                         }
                     }
                 }
             }
-            HStack(spacing: 4) {
-                ForEach(Array(tokens.enumerated()), id: \.0) { _, token in
-                    Text(token)
-                        .font(.system(size: 12, weight: .regular, design: .monospaced))
+            SwiftUI.HStack(spacing: 4) {
+                SwiftUI.ForEach(Array(tokens.enumerated()), id: \.0) { _, token in
+                    SwiftUI.Text(token)
+                        .font(SwiftUI.Font.system(size: 12, weight: .regular, design: .monospaced))
                 }
             }
         }


### PR DESCRIPTION
## Summary
- qualify SwiftUI types in streaming views to avoid collisions with Teatro's layout types
- guarantee sequential SSE event publishing to prevent dispatcher stalls

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68bda3049e808333940b8b04a463f127