### PR TITLE
fix(cli/preview): unbreak RenderCLI inference; add ScoreKitPreviewApp; fix .pi ambiguity

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "58b0498216e3ce0375d3b38b8c95a25d3abaecb4ccc8f83c8d2ac670e87f209f",
+  "originHash" : "5ead815f3c950c6b5baa74fb84d9529b7fd5ea0e2db48fd8e3f012b5d836fe54",
   "pins" : [
     {
       "identity" : "midi2",
@@ -34,7 +34,7 @@
       "location" : "https://github.com/Fountain-Coach/ScoreKit.git",
       "state" : {
         "branch" : "main",
-        "revision" : "75211b3f2d27c06c0b652e1242ced1a58ccb69c2"
+        "revision" : "28e4e27adbdba5d278cbad0e5c7f95f1b6d126cb"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -135,6 +135,14 @@ let package = Package(
             ],
             path: "Sources/TeatroPreviewDemo"
         ),
+        // macOS SwiftUI app for interactive ScoreKit preview
+        .executableTarget(
+            name: "ScoreKitPreviewApp",
+            dependencies: [
+                .product(name: "ScoreKit", package: "ScoreKit")
+            ],
+            path: "Sources/ScoreKitPreviewApp"
+        ),
 
         // MARK: - Tests
         .testTarget(

--- a/Sources/ScoreKitPreviewApp/main.swift
+++ b/Sources/ScoreKitPreviewApp/main.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import Foundation
+import ScoreKit
+
+@main
+struct ScoreKitPreviewApp: App {
+    @State private var events: [NotatedEvent] = []
+    @State private var selection: Int = 0
+    @State private var zoom: Double = 1.0
+
+    init() {
+        self._events = State(initialValue: Self.loadEvents())
+    }
+
+    var body: some Scene {
+        WindowGroup("ScoreKit Preview") {
+            VStack(spacing: 8) {
+                ScoreCanvas(events: events, selection: $selection, zoom: $zoom)
+                    .frame(minWidth: 900, minHeight: 240)
+                HStack {
+                    Button("Prev") { selection = max(0, selection - 1) }
+                    Button("Next") { selection = min(max(0, events.count - 1), selection + 1) }
+                    Spacer()
+                    Text("Zoom")
+                    Slider(value: $zoom, in: 0.5...2.0)
+                        .frame(width: 200)
+                }
+                .padding(.horizontal, 12)
+                .padding(.bottom, 8)
+            }
+        }
+    }
+
+    static func loadEvents() -> [NotatedEvent] {
+        let args = CommandLine.arguments
+        if let lyIdx = args.firstIndex(of: "--ly"), lyIdx + 1 < args.count {
+            let path = args[lyIdx + 1]
+            if let s = try? String(contentsOfFile: path), !s.isEmpty {
+                return LilyParser.parse(source: s)
+            }
+        }
+        // Try common fixture path relative to Teatro
+        let cwd = FileManager.default.currentDirectoryPath
+        let guess = URL(fileURLWithPath: cwd).appendingPathComponent("../ScoreKit/Fixtures/Lily/baseline_quarters.ly").standardized
+        if let s = try? String(contentsOf: guess), !s.isEmpty {
+            return LilyParser.parse(source: s)
+        }
+        // Fallback: C-D-E-F
+        return [
+            .init(base: .note(pitch: .init(step: .C, alter: 0, octave: 4), duration: .init(1,4))),
+            .init(base: .note(pitch: .init(step: .D, alter: 0, octave: 4), duration: .init(1,4))),
+            .init(base: .note(pitch: .init(step: .E, alter: 0, octave: 4), duration: .init(1,4))),
+            .init(base: .note(pitch: .init(step: .F, alter: 0, octave: 4), duration: .init(1,4)))
+        ]
+    }
+}
+
+struct ScoreCanvas: View {
+    let events: [NotatedEvent]
+    @Binding var selection: Int
+    @Binding var zoom: Double
+
+    private let paddingTop0: Double = 20
+    private let paddingLeft0: Double = 20
+    private let staffSpacing0: Double = 10
+    private let beatsPerBar: Int = 4
+    private let beatUnit: Int = 4
+
+    private func diatonicIndex(_ p: Pitch) -> Int {
+        let stepIndex: Int
+        switch p.step { case .C: stepIndex = 0; case .D: stepIndex = 1; case .E: stepIndex = 2; case .F: stepIndex = 3; case .G: stepIndex = 4; case .A: stepIndex = 5; case .B: stepIndex = 6 }
+        return p.octave * 7 + stepIndex
+    }
+    private func topLineDI() -> Int { 38 } // treble
+    private func yForPitch(_ p: Pitch, originY: Double, staffSpacing: Double) -> Double {
+        let pos = topLineDI() - diatonicIndex(p)
+        return originY + Double(pos) * (staffSpacing / 2.0)
+    }
+
+    private func layout(size: CGSize) -> (xs: [Double], ys: [Double], bars: [Double]) {
+        let paddingTop = paddingTop0 * zoom
+        let paddingLeft = paddingLeft0 * zoom
+        let staffSpacing = staffSpacing0 * zoom
+        var xs = Array(repeating: 0.0, count: events.count)
+        var ys = Array(repeating: 0.0, count: events.count)
+        var bars: [Double] = []
+        var x = paddingLeft
+        var barProgress = 0.0
+        for (i,e) in events.enumerated() {
+            switch e.base {
+            case let .note(p, _):
+                ys[i] = yForPitch(p, originY: paddingTop, staffSpacing: staffSpacing)
+                xs[i] = x
+                x += 28 * zoom
+            case .rest:
+                xs[i] = x
+                x += 28 * zoom
+            }
+            let frac = Double(beatUnit)/4.0
+            barProgress += frac
+            if barProgress >= Double(beatsPerBar) {
+                barProgress -= Double(beatsPerBar)
+                bars.append(x)
+            }
+        }
+        return (xs, ys, bars)
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            Canvas { ctx, size in
+                let (xs, ys, bars) = layout(size: size)
+                let paddingTop = paddingTop0 * zoom
+                let paddingLeft = paddingLeft0 * zoom
+                let staffSpacing = staffSpacing0 * zoom
+                // Staff lines
+                let left = paddingLeft
+                let right = size.width - paddingLeft
+                var path = Path()
+                for i in 0..<5 {
+                    let y = paddingTop + staffSpacing * Double(i)
+                    path.move(to: CGPoint(x: left, y: y))
+                    path.addLine(to: CGPoint(x: right, y: y))
+                }
+                ctx.stroke(path, with: .color(.black), lineWidth: 1)
+
+                // Notes
+                for (i, ev) in events.enumerated() {
+                    guard case .note = ev.base else { continue }
+                    let x = xs[i]; let y = ys[i]
+                    let rx = 4.8 * zoom
+                    let ry = 3.2 * zoom
+                    var head = Path(ellipseIn: CGRect(x: x - rx, y: y - ry, width: rx*2, height: ry*2))
+                    // Use an explicit Double for pi to avoid ambiguity across Float/Double/CGFloat
+                    let angle = CGFloat(-20.0 * Double.pi / 180.0)
+                    var transform = CGAffineTransform(translationX: x, y: y)
+                        .rotated(by: angle)
+                        .translatedBy(x: -x, y: -y)
+                    head = head.applying(transform)
+                    ctx.fill(head, with: .color(i == selection ? .red : .black))
+                    // Stem
+                    let midY = paddingTop + staffSpacing * 2.0
+                    let stemUp = y >= midY
+                    let stemLen = staffSpacing * 3.5
+                    let x1 = stemUp ? (x + rx - 1) : (x - rx + 1)
+                    let y1 = y
+                    let y2 = stemUp ? (y - stemLen) : (y + stemLen)
+                    var stem = Path()
+                    stem.move(to: CGPoint(x: x1, y: y1))
+                    stem.addLine(to: CGPoint(x: x1, y: y2))
+                    ctx.stroke(stem, with: .color(.black), lineWidth: 1)
+                }
+
+                // Barlines
+                let topY = paddingTop - staffSpacing * 0.5
+                let bottomY = paddingTop + staffSpacing * 4.0 + staffSpacing * 0.5
+                var barsPath = Path()
+                for bx in bars {
+                    barsPath.move(to: CGPoint(x: bx, y: topY))
+                    barsPath.addLine(to: CGPoint(x: bx, y: bottomY))
+                }
+                ctx.stroke(barsPath, with: .color(.black), lineWidth: 1)
+            }
+            .background(Color.white)
+        }
+    }
+}

--- a/Sources/TeatroRenderAPI/ScoreKitPreview.swift
+++ b/Sources/TeatroRenderAPI/ScoreKitPreview.swift
@@ -16,6 +16,19 @@ public enum ScoreKitPreview {
         var layoutY: [Double] = []
         var barX: [Double] = []
 
+        func diatonicIndex(_ p: Pitch) -> Int {
+            let stepIndex: Int
+            switch p.step { case .C: stepIndex = 0; case .D: stepIndex = 1; case .E: stepIndex = 2; case .F: stepIndex = 3; case .G: stepIndex = 4; case .A: stepIndex = 5; case .B: stepIndex = 6 }
+            return p.octave * 7 + stepIndex
+        }
+        func topLineDI(for clef: ClefType) -> Int { clef == .treble ? 38 : 26 }
+        func yForPitch(_ p: Pitch, clef: ClefType, originY: Double, staffSpacing: Double) -> Double {
+            let di = diatonicIndex(p)
+            let top = topLineDI(for: clef)
+            let pos = top - di
+            return originY + Double(pos) * (staffSpacing / 2.0)
+        }
+
         func computeLayout(staffSpacing: Double, paddingTop: Double, paddingLeft: Double, beatsPerBar: Int = 4, beatUnit: Int = 4) {
             layoutX = Array(repeating: 0, count: events.count)
             layoutY = Array(repeating: 0, count: events.count)
@@ -25,7 +38,7 @@ public enum ScoreKitPreview {
             for (i, e) in events.enumerated() {
                 switch e.base {
                 case let .note(p, _):
-                    let y = StaffCoords.y(for: p, clef: .treble, originY: paddingTop, staffSpacing: staffSpacing)
+                    let y = yForPitch(p, clef: ClefType.treble, originY: paddingTop, staffSpacing: staffSpacing)
                     layoutX[i] = x
                     layoutY[i] = y
                     x += quarterAdvance

--- a/Sources/TeatroScoreKitRenderer/ScoreKitPNGRasterizer.swift
+++ b/Sources/TeatroScoreKitRenderer/ScoreKitPNGRasterizer.swift
@@ -7,7 +7,8 @@ import ScoreKit
 
 public struct ScoreKitPNGRasterizer: RendererPlugin {
     public static let identifier = "scorekit-png"
-    public static let fileExtensions = ["png"]
+    // Do not hijack the generic PNG extension; require explicit --format scorekit-png
+    public static let fileExtensions: [String] = []
 
     public static func render(view: Renderable, output: String?) throws {
         guard let score = (view as? ScoreView) else {

--- a/Sources/TeatroScoreKitRenderer/ScoreKitSVGRenderer.swift
+++ b/Sources/TeatroScoreKitRenderer/ScoreKitSVGRenderer.swift
@@ -6,7 +6,8 @@ import ScoreKit
 // Goal: provide a deterministic, calibrated coordinate space and draw staff + noteheads.
 public struct ScoreKitSVGRenderer: RendererPlugin {
     public static let identifier = "scorekit-svg"
-    public static let fileExtensions = ["svg"]
+    // Do not hijack the generic SVG extension; require explicit --format scorekit-svg
+    public static let fileExtensions: [String] = []
 
     public static func render(view: Renderable, output: String?) throws {
         guard let score = (view as? ScoreView) else {


### PR DESCRIPTION
Summary\n- Fix CLI extension/format inference by not claiming generic .svg/.png in ScoreKit renderer plugins. Users opt-in via --format scorekit-svg or --format scorekit-png.\n- Add macOS SwiftUI target ScoreKitPreviewApp for interactive ScoreKit previews.\n- Resolve ambiguous .pi usage in preview rotation by casting via Double.pi.\n- Keep ScoreKitPreview pitch mapping self-contained.\n\nWhy\n- RenderCLICoverageTests failed due to extension/format mismatch when ScoreKit plugins hijacked generic extensions.\n- Preview app build failed due to ambiguous .pi across Float/Double/CGFloat.\n\nValidation\n- swift test passes for both ScoreKit and Teatro locally.\n- No external behavior change unless --format scorekit-* is explicitly used.\n\nNotes\n- Package.resolved updated for ScoreKit revision.\n\nCloses: n/a